### PR TITLE
Clean up chat TTS handling and message field styling

### DIFF
--- a/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -105,10 +104,6 @@ fun ChatScreen(
                         .heightIn(min = 80.dp),
                     label = { Text("Message") },
                     shape = RoundedCornerShape(24.dp),
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant
-                    ),
                     maxLines = 5,
                     minLines = 3
                 )

--- a/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -206,11 +205,7 @@ fun ChatTtsScreen(
                     onValueChange = { message = it },
                     modifier = Modifier.weight(1f),
                     label = { Text("Message") },
-                    shape = RoundedCornerShape(24.dp),
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant
-                    )
+                    shape = RoundedCornerShape(24.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Button(

--- a/app/src/main/java/com/example/nabu/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/ChatTtsViewModel.kt
@@ -76,18 +76,26 @@ class ChatTtsViewModel(
     private val _speed = MutableStateFlow(1.0f)
     val speed = _speed.asStateFlow()
 
-    private val audioQueue = Channel<FloatArray>(Channel.UNLIMITED)
+    private val audioQueue = Channel<Pair<Int, FloatArray>>(Channel.UNLIMITED)
+    private var lineIndex = 0
 
     init {
         llmInference.initialize()
-        // Launch a coroutine to play queued audio sequentially
+        // Launch a coroutine to play queued audio in the order they were generated
         viewModelScope.launch {
-            for (audio in audioQueue) {
-                try {
-                    audioPlayer.prepare(audio)
-                    audioPlayer.playBlocking()
-                } catch (e: Exception) {
-                    DebugLogger.log("Audio playback error: ${e.localizedMessage}")
+            val pending = mutableMapOf<Int, FloatArray>()
+            var nextIndex = 0
+            for ((index, audio) in audioQueue) {
+                pending[index] = audio
+                while (pending.containsKey(nextIndex)) {
+                    val data = pending.remove(nextIndex)!!
+                    try {
+                        audioPlayer.prepare(data)
+                        audioPlayer.playBlocking()
+                    } catch (e: Exception) {
+                        DebugLogger.log("Audio playback error: ${e.localizedMessage}")
+                    }
+                    nextIndex++
                 }
             }
         }
@@ -144,7 +152,7 @@ class ChatTtsViewModel(
             val end = match.range.last + 1
             val sentence = text.substring(0, end).trim()
             DebugLogger.log("Queueing sentence: $sentence")
-            synthesizeAndQueue(sentence)
+            synthesizeAndQueue(cleanText(sentence))
             text = text.substring(end)
             match = regex.find(text)
         }
@@ -153,11 +161,12 @@ class ChatTtsViewModel(
         if (done && builder.isNotEmpty()) {
             val sentence = builder.toString().trim()
             builder.clear()
-            synthesizeAndQueue(sentence)
+            synthesizeAndQueue(cleanText(sentence))
         }
     }
 
     private fun synthesizeAndQueue(text: String) {
+        val currentIndex = lineIndex++
         viewModelScope.launch {
             _isSynthesizing.value = true
             try {
@@ -200,13 +209,19 @@ class ChatTtsViewModel(
                     }
                     data
                 }
-                audioQueue.send(audioData)
+                audioQueue.send(currentIndex to audioData)
             } catch (e: Exception) {
                 DebugLogger.log("Error synthesizing sentence: ${e.localizedMessage}")
             } finally {
                 _isSynthesizing.value = false
             }
         }
+    }
+
+    private fun cleanText(text: String): String {
+        val replaced = text.replace("\\n", "\n").replace("/n", "\n")
+        val markdownRegex = Regex("[*_`>#\\[\\](){},]")
+        return replaced.replace(markdownRegex, "")
     }
 
     // --- Mixer State Updaters ---


### PR DESCRIPTION
## Summary
- Strip markdown characters and '/n' tokens before TTS synthesis
- Queue audio with line indices to maintain playback order
- Remove custom colors from chat message input fields to match theme

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e88ec4ea08331be1187238a185ca0