### PR TITLE
Add TTS toggle control in chat screen

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -59,6 +61,7 @@ fun ChatTtsScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isSynthesizing by viewModel.isSynthesizing.collectAsState()
     val playerState by viewModel.playerState.collectAsState()
+    val ttsEnabled by viewModel.ttsEnabled.collectAsState()
 
     val selectedStyles by viewModel.selectedStyles.collectAsState()
     val weights by viewModel.weights.collectAsState()
@@ -82,6 +85,13 @@ fun ChatTtsScreen(
                 navigationIcon = {
                     IconButton(onClick = onBackPressed) {
                         Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.toggleTtsEnabled() }) {
+                        val icon = if (ttsEnabled) Icons.Filled.VolumeUp else Icons.Filled.VolumeOff
+                        val desc = if (ttsEnabled) "Disable TTS" else "Enable TTS"
+                        Icon(icon, contentDescription = desc)
                     }
                 }
             )

--- a/app/src/main/java/com/example/nabu/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/ChatTtsViewModel.kt
@@ -63,6 +63,9 @@ class ChatTtsViewModel(
     private val _playerState = MutableStateFlow(PlayerState.IDLE)
     val playerState = _playerState.asStateFlow()
 
+    private val _ttsEnabled = MutableStateFlow(true)
+    val ttsEnabled = _ttsEnabled.asStateFlow()
+
     // Mixer State
     private val _selectedStyles = MutableStateFlow(listOf(defaultVoice))
     val selectedStyles = _selectedStyles.asStateFlow()
@@ -98,6 +101,14 @@ class ChatTtsViewModel(
                     nextIndex++
                 }
             }
+        }
+    }
+
+    fun toggleTtsEnabled() {
+        val enabled = !_ttsEnabled.value
+        _ttsEnabled.value = enabled
+        if (!enabled) {
+            audioPlayer.stop()
         }
     }
 
@@ -166,6 +177,7 @@ class ChatTtsViewModel(
     }
 
     private fun synthesizeAndQueue(text: String) {
+        if (!_ttsEnabled.value) return
         val currentIndex = lineIndex++
         viewModelScope.launch {
             _isSynthesizing.value = true


### PR DESCRIPTION
## Summary
- Allow enabling or disabling speech synthesis directly from the chat TTS screen
- Maintain TTS enabled state in `ChatTtsViewModel` and stop audio when disabled

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d6efbf4833187fbed2b8e012de8