### PR TITLE
Add PCM tap and waveform visualizer for TTS audio

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
@@ -48,7 +48,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.kokoro.chat.MessageBubble
 import com.example.nabu.utils.PlayerState
+import com.example.nabu.utils.PcmTap
 import com.example.nabu.viewmodel.ChatTtsViewModel
+import com.example.nabu.ui.components.WaveformVisualizer
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -62,6 +64,10 @@ fun ChatTtsScreen(
     val isSynthesizing by viewModel.isSynthesizing.collectAsState()
     val playerState by viewModel.playerState.collectAsState()
     val ttsEnabled by viewModel.ttsEnabled.collectAsState()
+
+    LaunchedEffect(playerState) {
+        PcmTap.enabled = playerState == PlayerState.PLAYING
+    }
 
     val selectedStyles by viewModel.selectedStyles.collectAsState()
     val weights by viewModel.weights.collectAsState()
@@ -178,6 +184,13 @@ fun ChatTtsScreen(
                     if(isLoading || isSynthesizing) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 }
             }
+
+            WaveformVisualizer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                visible = playerState == PlayerState.PLAYING
+            )
 
             // Chat Messages
             LazyColumn(

--- a/app/src/main/java/com/example/nabu/ui/components/WaveformVisualizer.kt
+++ b/app/src/main/java/com/example/nabu/ui/components/WaveformVisualizer.kt
@@ -1,0 +1,60 @@
+package com.example.nabu.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.nabu.utils.PcmTap
+import kotlinx.coroutines.delay
+
+/**
+ * Simple waveform visualizer composable. Draws lines based on PCM amplitude.
+ */
+@Composable
+fun WaveformVisualizer(
+    modifier: Modifier = Modifier,
+    sampleCount: Int = 1024,
+    lineColor: Color = Color.Blue,
+    visible: Boolean = true,
+) {
+    var samples by remember { mutableStateOf(FloatArray(sampleCount)) }
+    LaunchedEffect(visible) {
+        while (visible) {
+            if (PcmTap.enabled) {
+                samples = PcmTap.getLastSamples(sampleCount)
+            }
+            delay(16)
+        }
+    }
+
+    AnimatedVisibility(visible) {
+        Canvas(modifier = modifier.fillMaxWidth().height(100.dp)) {
+            val width = size.width
+            val height = size.height
+            val halfHeight = height / 2f
+            val step = width / (sampleCount - 1).toFloat()
+            for (i in 0 until sampleCount - 1) {
+                val x1 = i * step
+                val y1 = halfHeight - (samples[i] * halfHeight)
+                val x2 = (i + 1) * step
+                val y2 = halfHeight - (samples[i + 1] * halfHeight)
+                drawLine(
+                    color = lineColor,
+                    start = Offset(x1, y1),
+                    end = Offset(x2, y2),
+                    strokeWidth = 2f,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/nabu/utils/KittenAudioPlayer.kt
+++ b/app/src/main/java/com/example/nabu/utils/KittenAudioPlayer.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.isActive
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.math.min
 
 class KittenAudioPlayer(
     private val scope: CoroutineScope,
@@ -18,6 +19,7 @@ class KittenAudioPlayer(
 ) : AudioPlayer {
     private var audioTrack: AudioTrack? = null
     private var pcmData: ByteArray? = null
+    private var audioFloats: FloatArray? = null
     private var position: Int = 0
     private var currentState: PlayerState = PlayerState.IDLE
         set(value) {
@@ -30,7 +32,7 @@ class KittenAudioPlayer(
     override fun prepare(audio: FloatArray, position: Int) {
         DebugLogger.log("KittenAudioPlayer prepare length=${audio.size}, position=$position")
         release() // Release any existing track
-        PcmTap.pushFloats(audio)
+        audioFloats = audio
         val channelConfig = AudioFormat.CHANNEL_OUT_MONO
         val audioFormat = AudioFormat.ENCODING_PCM_16BIT
         val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)
@@ -73,10 +75,22 @@ class KittenAudioPlayer(
             DebugLogger.log("KittenAudioPlayer start play from position $position")
             currentState = PlayerState.PLAYING
             track.play()
-            track.write(data, position, data.size - position)
-            // Wait for playback to complete if not paused
-            while (track.playbackHeadPosition < (data.size - position) / 2 && currentState == PlayerState.PLAYING) {
-                kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
+            val chunkSize = 4096
+            while (position < data.size && currentState == PlayerState.PLAYING && isActive) {
+                val remaining = data.size - position
+                val toWrite = min(chunkSize, remaining)
+                val bytePos = position
+                val written = track.write(data, position, toWrite)
+                if (written > 0) {
+                    val actualSamples = written / 2
+                    audioFloats?.let { PcmTap.pushFloats(it, bytePos / 2, actualSamples) }
+                    position += written
+                } else {
+                    break
+                }
+            }
+            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING && isActive) {
+                kotlinx.coroutines.delay(10)
             }
             if (currentState != PlayerState.PAUSED) {
                 stop()
@@ -97,10 +111,22 @@ class KittenAudioPlayer(
             DebugLogger.log("KittenAudioPlayer start play blocking from position $position")
             currentState = PlayerState.PLAYING
             track.play()
-            track.write(data, position, data.size - position)
-            // Wait for playback to complete if not paused
-            while (track.playbackHeadPosition < (data.size - position) / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
-                kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
+            val chunkSize = 4096
+            while (position < data.size && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+                val remaining = data.size - position
+                val toWrite = min(chunkSize, remaining)
+                val bytePos = position
+                val written = track.write(data, position, toWrite)
+                if (written > 0) {
+                    val actualSamples = written / 2
+                    audioFloats?.let { PcmTap.pushFloats(it, bytePos / 2, actualSamples) }
+                    position += written
+                } else {
+                    break
+                }
+            }
+            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+                kotlinx.coroutines.delay(10)
             }
             if (currentState != PlayerState.PAUSED) {
                 stop()
@@ -138,6 +164,7 @@ class KittenAudioPlayer(
         audioTrack?.flush()
         audioTrack?.release()
         audioTrack = null
+        audioFloats = null
         position = 0
     }
 

--- a/app/src/main/java/com/example/nabu/utils/KittenAudioPlayer.kt
+++ b/app/src/main/java/com/example/nabu/utils/KittenAudioPlayer.kt
@@ -30,6 +30,7 @@ class KittenAudioPlayer(
     override fun prepare(audio: FloatArray, position: Int) {
         DebugLogger.log("KittenAudioPlayer prepare length=${audio.size}, position=$position")
         release() // Release any existing track
+        PcmTap.pushFloats(audio)
         val channelConfig = AudioFormat.CHANNEL_OUT_MONO
         val audioFormat = AudioFormat.ENCODING_PCM_16BIT
         val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)

--- a/app/src/main/java/com/example/nabu/utils/KokoroAudioPlayer.kt
+++ b/app/src/main/java/com/example/nabu/utils/KokoroAudioPlayer.kt
@@ -30,6 +30,7 @@ class KokoroAudioPlayer(
     override fun prepare(audio: FloatArray, position: Int) {
         DebugLogger.log("KokoroAudioPlayer prepare length=${audio.size}, position=$position")
         release() // Release any existing track
+        PcmTap.pushFloats(audio)
         val channelConfig = AudioFormat.CHANNEL_OUT_MONO
         val audioFormat = AudioFormat.ENCODING_PCM_16BIT
         val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)

--- a/app/src/main/java/com/example/nabu/utils/KokoroAudioPlayer.kt
+++ b/app/src/main/java/com/example/nabu/utils/KokoroAudioPlayer.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.isActive
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.math.min
 
 class KokoroAudioPlayer(
     private val scope: CoroutineScope,
@@ -18,6 +19,7 @@ class KokoroAudioPlayer(
 ) : AudioPlayer {
     private var audioTrack: AudioTrack? = null
     private var pcmData: ByteArray? = null
+    private var audioFloats: FloatArray? = null
     private var position: Int = 0
     private var currentState: PlayerState = PlayerState.IDLE
         set(value) {
@@ -30,7 +32,7 @@ class KokoroAudioPlayer(
     override fun prepare(audio: FloatArray, position: Int) {
         DebugLogger.log("KokoroAudioPlayer prepare length=${audio.size}, position=$position")
         release() // Release any existing track
-        PcmTap.pushFloats(audio)
+        audioFloats = audio
         val channelConfig = AudioFormat.CHANNEL_OUT_MONO
         val audioFormat = AudioFormat.ENCODING_PCM_16BIT
         val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)
@@ -73,10 +75,22 @@ class KokoroAudioPlayer(
             DebugLogger.log("KokoroAudioPlayer start play from position $position")
             currentState = PlayerState.PLAYING
             track.play()
-            track.write(data, position, data.size - position)
-            // Wait for playback to complete if not paused
-            while (track.playbackHeadPosition < (data.size - position) / 2 && currentState == PlayerState.PLAYING) {
-                kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
+            val chunkSize = 4096
+            while (position < data.size && currentState == PlayerState.PLAYING && isActive) {
+                val remaining = data.size - position
+                val toWrite = min(chunkSize, remaining)
+                val bytePos = position
+                val written = track.write(data, position, toWrite)
+                if (written > 0) {
+                    val actualSamples = written / 2
+                    audioFloats?.let { PcmTap.pushFloats(it, bytePos / 2, actualSamples) }
+                    position += written
+                } else {
+                    break
+                }
+            }
+            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING && isActive) {
+                kotlinx.coroutines.delay(10)
             }
             if (currentState != PlayerState.PAUSED) {
                 stop()
@@ -97,10 +111,22 @@ class KokoroAudioPlayer(
             DebugLogger.log("KokoroAudioPlayer start play blocking from position $position")
             currentState = PlayerState.PLAYING
             track.play()
-            track.write(data, position, data.size - position)
-            // Wait for playback to complete if not paused
-            while (track.playbackHeadPosition < (data.size - position) / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
-                kotlinx.coroutines.delay(10) // Small delay to prevent busy-waiting
+            val chunkSize = 4096
+            while (position < data.size && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+                val remaining = data.size - position
+                val toWrite = min(chunkSize, remaining)
+                val bytePos = position
+                val written = track.write(data, position, toWrite)
+                if (written > 0) {
+                    val actualSamples = written / 2
+                    audioFloats?.let { PcmTap.pushFloats(it, bytePos / 2, actualSamples) }
+                    position += written
+                } else {
+                    break
+                }
+            }
+            while (track.playbackHeadPosition < data.size / 2 && currentState == PlayerState.PLAYING && coroutineContext.isActive) {
+                kotlinx.coroutines.delay(10)
             }
             if (currentState != PlayerState.PAUSED) {
                 stop()
@@ -138,6 +164,7 @@ class KokoroAudioPlayer(
         audioTrack?.flush()
         audioTrack?.release()
         audioTrack = null
+        audioFloats = null
         position = 0
     }
 

--- a/app/src/main/java/com/example/nabu/utils/PcmTap.kt
+++ b/app/src/main/java/com/example/nabu/utils/PcmTap.kt
@@ -1,0 +1,43 @@
+package com.example.nabu.utils
+
+import kotlin.math.min
+
+/**
+ * Lock-free ring buffer for PCM snapshots (power-of-two capacity).
+ * Push from the audio thread; draw from the UI thread.
+ */
+object PcmTap {
+    private const val CAP = 8192 // Power of two for fast masking
+    private const val MASK = CAP - 1
+    private val buf = FloatArray(CAP)
+    @Volatile private var w = 0 // Write position
+    @Volatile var enabled: Boolean = true // Toggle to pause capturing
+
+    /** Push floats in [-1, 1]. Zero-alloc, branch-light. */
+    fun pushFloats(src: FloatArray, off: Int = 0, len: Int = src.size) {
+        if (!enabled) return
+        var i = 0
+        val L = min(len, src.size - off)
+        var wi = w
+        while (i < L) {
+            buf[wi and MASK] = src[off + i].coerceIn(-1f, 1f)
+            wi = (wi + 1) and MASK
+            i++
+        }
+        w = wi
+    }
+
+    /** Snapshot the last [n] samples for drawing (UI thread). */
+    fun getLastSamples(n: Int): FloatArray {
+        val out = FloatArray(n)
+        val wi = w
+        var ri = (wi - n) and MASK
+        var i = 0
+        while (i < n) {
+            out[i] = buf[ri]
+            ri = (ri + 1) and MASK
+            i++
+        }
+        return out
+    }
+}

--- a/app/src/main/java/com/example/nabu/utils/PlayAudio.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlayAudio.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import kotlin.math.min
 
 fun playAudio(audioData: FloatArray, sampleRate: Int, scope: CoroutineScope, onComplete: () -> Unit) {
     scope.launch(Dispatchers.IO) {
@@ -30,15 +31,30 @@ fun playAudio(audioData: FloatArray, sampleRate: Int, scope: CoroutineScope, onC
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
         val shortBuffer = byteBuffer.asShortBuffer()
 
-        PcmTap.pushFloats(audioData)
         for (sample in audioData) {
             val pcmValue = (sample * Short.MAX_VALUE).toInt().toShort()
             shortBuffer.put(pcmValue)
         }
 
         audioTrack.play()
-        audioTrack.write(byteBuffer.array(), 0, byteBuffer.array().size)
 
+        val pcmBytes = byteBuffer.array()
+        val chunkSize = 4096
+        var pos = 0
+        while (pos < pcmBytes.size) {
+            val remaining = pcmBytes.size - pos
+            val toWrite = min(chunkSize, remaining)
+            val floatStart = pos / 2
+            val written = audioTrack.write(pcmBytes, pos, toWrite)
+            if (written > 0) {
+                PcmTap.pushFloats(audioData, floatStart, written / 2)
+                pos += written
+            } else {
+                break
+            }
+        }
+
+        audioTrack.stop()
         audioTrack.release()
 
         withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/example/nabu/utils/PlayAudio.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlayAudio.kt
@@ -30,6 +30,7 @@ fun playAudio(audioData: FloatArray, sampleRate: Int, scope: CoroutineScope, onC
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
         val shortBuffer = byteBuffer.asShortBuffer()
 
+        PcmTap.pushFloats(audioData)
         for (sample in audioData) {
             val pcmValue = (sample * Short.MAX_VALUE).toInt().toShort()
             shortBuffer.put(pcmValue)


### PR DESCRIPTION
## Summary
- Add `PcmTap` ring buffer for capturing recent PCM samples
- Implement `WaveformVisualizer` composable to render audio waveform
- Feed tap from audio players and show waveform in ChatTts screen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b75c8ca0833198e412346d3659fd