### PR TITLE
Credit jsoup author and show white waveform

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ This project would not be possible without the amazing work of the open-source c
     *   ONNX Runtime for on-device inference.
     *   Jetpack Compose for the user interface.
     *   [IPA-Transcribers](https://github.com/kotlinguistics/IPA-Transcribers) for phoneme generation.
+    *   [jsoup](https://jsoup.org/) HTML parser used for EPUB support (MIT) by Jonathan Hedley.

--- a/app/src/main/java/com/example/nabu/screens/CreditsConstellationScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/CreditsConstellationScreen.kt
@@ -102,7 +102,11 @@ fun CreditsConstellationScreen() {
                 ),
                 CreditEntry(
                     "LiteRT community on Hugging Face",
-                    "https://huggingface.co/litert-community"
+                    "https://huggingface.co/litert-community",
+                ),
+                CreditEntry(
+                    "jsoup: HTML parser for EPUB support (MIT) by Jonathan Hedley",
+                    "https://jsoup.org/",
                 )
             )
         )

--- a/app/src/main/java/com/example/nabu/ui/components/WaveformVisualizer.kt
+++ b/app/src/main/java/com/example/nabu/ui/components/WaveformVisualizer.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.delay
 fun WaveformVisualizer(
     modifier: Modifier = Modifier,
     sampleCount: Int = 1024,
-    lineColor: Color = Color.Blue,
+    lineColor: Color = Color.White,
     visible: Boolean = true,
 ) {
     var samples by remember { mutableStateOf(FloatArray(sampleCount)) }


### PR DESCRIPTION
## Summary
- Add jsoup HTML parser and author to credits
- Render waveform visualizer in white for better contrast

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fbe9f2808331ae567563d6ef0e4c