### PR TITLE
feat: add audio brutalist theme building blocks

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BrutalistBookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BrutalistBookScreen.kt
@@ -1,0 +1,73 @@
+package com.example.nabu.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.nabu.ui.components.ChapterList
+import com.example.nabu.ui.components.RadialAudioVisualizer
+import com.example.nabu.ui.components.SegmentedChapterProgress
+
+/**
+ * Demonstration screen showcasing the "Audio‑Brutalist" layout.
+ * The UI is organised into three rigid vertical modules:
+ *
+ * 1. **Engine**   – Occupies the top half and hosts the central visualiser.
+ * 2. **Console**  – Provides context and progress information.
+ * 3. **Archive**  – Scrollable list of selectable chapters.
+ */
+@Composable
+fun BrutalistBookScreen(
+    chapterTitles: List<String>,
+    currentChapter: Int,
+    amplitudes: List<Float>,
+    isPlaying: Boolean,
+    onChapterSelected: (Int) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Engine
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            RadialAudioVisualizer(
+                amplitudes = amplitudes,
+                isPlaying = isPlaying,
+                modifier = Modifier.fillMaxSize(0.8f)
+            )
+        }
+
+        // Console
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = chapterTitles.getOrNull(currentChapter) ?: "",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            SegmentedChapterProgress(
+                totalChapters = chapterTitles.size,
+                currentChapter = currentChapter
+            )
+        }
+
+        // Archive
+        ChapterList(
+            chapters = chapterTitles,
+            currentIndex = currentChapter,
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp),
+            onChapterSelected = onChapterSelected
+        )
+    }
+}

--- a/app/src/main/java/com/example/nabu/ui/components/AudioBrutalistComponents.kt
+++ b/app/src/main/java/com/example/nabu/ui/components/AudioBrutalistComponents.kt
@@ -1,0 +1,149 @@
+package com.example.nabu.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+/**
+ * A radial visualiser that echoes the brutalist design ethos.  When audio is
+ * playing a set of geometric bars radiate from the centre in proportion to the
+ * provided amplitudes.  When paused the visualiser collapses into a thin ring
+ * that gently "breathes" to indicate readiness.
+ */
+@Composable
+fun RadialAudioVisualizer(
+    amplitudes: List<Float>,
+    isPlaying: Boolean,
+    modifier: Modifier = Modifier,
+    barColor: Color = MaterialTheme.colorScheme.primary
+) {
+    val bars = if (amplitudes.isEmpty()) List(64) { 0f } else amplitudes
+    val transition = rememberInfiniteTransition(label = "breath")
+    val breath by transition.animateFloat(
+        initialValue = 0.95f,
+        targetValue = 1.05f,
+        animationSpec = infiniteRepeatable(
+            tween(durationMillis = 2000, easing = LinearEasing),
+            RepeatMode.Reverse
+        ),
+        label = "breathAnim"
+    )
+
+    Canvas(modifier = modifier) {
+        val radius = min(size.width, size.height) / 2f
+        val barCount = bars.size
+        for (i in 0 until barCount) {
+            val angle = (2 * PI * i / barCount).toFloat()
+            val lineLength = if (isPlaying) radius * bars[i].coerceIn(0f, 1f) else 0f
+            val start = Offset(
+                x = center.x + cos(angle) * (radius - lineLength),
+                y = center.y + sin(angle) * (radius - lineLength)
+            )
+            val end = Offset(
+                x = center.x + cos(angle) * radius,
+                y = center.y + sin(angle) * radius
+            )
+            drawLine(
+                color = barColor,
+                start = start,
+                end = end,
+                strokeWidth = 2.dp.toPx()
+            )
+        }
+        if (!isPlaying) {
+            drawCircle(
+                color = barColor,
+                radius = radius * breath,
+                style = Stroke(width = 2.dp.toPx())
+            )
+        }
+    }
+}
+
+/**
+ * Displays overall book progress as a row of discrete horizontal segments,
+ * resembling a speaker grille.
+ */
+@Composable
+fun SegmentedChapterProgress(
+    totalChapters: Int,
+    currentChapter: Int,
+    modifier: Modifier = Modifier,
+    segmentWidth: Dp = 8.dp,
+    spacing: Dp = 4.dp,
+    activeColor: Color = MaterialTheme.colorScheme.primary,
+    inactiveColor: Color = MaterialTheme.colorScheme.secondary
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing)
+    ) {
+        repeat(totalChapters) { index ->
+            Box(
+                modifier = Modifier
+                    .width(segmentWidth)
+                    .height(4.dp)
+                    .background(if (index < currentChapter) activeColor else inactiveColor)
+            )
+        }
+    }
+}
+
+/**
+ * Simple vertically scrolling list of chapters.  Each chapter is rendered as a
+ * uniform block; the currently playing chapter receives a solid fill to
+ * distinguish it from the rest.
+ */
+@Composable
+fun ChapterList(
+    chapters: List<String>,
+    currentIndex: Int,
+    modifier: Modifier = Modifier,
+    onChapterSelected: (Int) -> Unit
+) {
+    LazyColumn(modifier = modifier) {
+        itemsIndexed(chapters) { index, title ->
+            val isCurrent = index == currentIndex
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+                    .background(
+                        color = if (isCurrent) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .clickable { onChapterSelected(index) }
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (isCurrent) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/nabu/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/nabu/ui/theme/Color.kt
@@ -2,36 +2,34 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 
+// The brutalist palette is intentionally stark and relies on a limited
+// range of utilitarian greys.  Bright accents are avoided so that the
+// central audio visualiser becomes the only source of motion and colour
+// within the interface.
+
 val LightColorScheme = lightColorScheme(
-    primary = Color(0xFF3F51B5), // Your main Indigo color (Unchanged)
+    primary = Color(0xFF000000),
     onPrimary = Color(0xFFFFFFFF),
-
-    // User's message bubble: A brighter, more modern light blue.
-    primaryContainer = Color(0xFFDDE2FF),
-    onPrimaryContainer = Color(0xFF001257), // Dark blue text for readability
-
-    secondary = Color(0xFF212121),
+    secondary = Color(0xFF444444),
     onSecondary = Color(0xFFFFFFFF),
-
-    // Assistant's message bubble: A clean, modern light gray.
-    secondaryContainer = Color(0xFFF1F2F6),
-    onSecondaryContainer = Color(0xFF1B1B1F), // Dark gray text for readability
+    background = Color(0xFFFFFFFF),
+    onBackground = Color(0xFF000000),
+    surface = Color(0xFFFFFFFF),
+    onSurface = Color(0xFF000000)
 )
 
-// --- UPDATED DARK COLOR SCHEME ---
 val DarkColorScheme = darkColorScheme(
-    primary = Color(0xFF899190), // Your main Indigo color (Unchanged)
-    onPrimary = Color(0xFFFFFFFF),
-
-    // User's message bubble: A brighter, more modern light blue.
-    primaryContainer = Color(0xFFDDE2FF),
-    onPrimaryContainer = Color(0xFF001257), // Dark blue text for readability
-
-    secondary = Color(0xFF212121),
-    onSecondary = Color(0xFFFFFFFF),
-    // Assistant's message bubble: A clean, modern light gray.
-    secondaryContainer = Color(0xFFF1F2F6),
-    onSecondaryContainer = Color(0xFF1B1B1F), // Dark gray text for readability
+    primary = Color(0xFFFFFFFF),
+    onPrimary = Color(0xFF000000),
+    secondary = Color(0xFF888888),
+    onSecondary = Color(0xFF000000),
+    background = Color(0xFF000000),
+    onBackground = Color(0xFFFFFFFF),
+    surface = Color(0xFF000000),
+    onSurface = Color(0xFFFFFFFF)
 )
+
+// Links retain a subtle hint of colour to indicate interactivity while
+// remaining within the overall monochrome scheme.
 val LinkColorLight = Color(0xFF3F51B5)
 val LinkColorDark = Color(0xFF9FA8DA)

--- a/app/src/main/java/com/example/nabu/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/nabu/ui/theme/Theme.kt
@@ -1,26 +1,19 @@
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import com.example.nabu.ui.theme.AppTypography
 
+/**
+ * Root theme that applies the "Audio‑Brutalist" aesthetic.  Dynamic colours are
+ * intentionally avoided to preserve the strict monochrome palette.  Only the
+ * central audio visualiser is expected to provide expressive motion or colour.
+ */
 @Composable
 fun NabuTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val isDynamicColorSupported = dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-
-    val colorScheme = when {
-        isDynamicColorSupported && darkTheme -> dynamicDarkColorScheme(LocalContext.current)
-        isDynamicColorSupported && !darkTheme -> dynamicLightColorScheme(LocalContext.current)
-        darkTheme -> DarkColorScheme
-        else -> LightColorScheme
-    }
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
 
     MaterialTheme(
         colorScheme = colorScheme,


### PR DESCRIPTION
## Summary
- replace color scheme with stark monochrome brutalist palette
- simplify root theme and remove dynamic colors
- add composables for radial visualizer, segmented progress, chapter list, and example screen

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68a106a0ecfc8331a1749576ca349282