### PR TITLE
Add phonemizer with text mode options and misaki/espeak fallback

### DIFF
--- a/core/settings/TextModeState.kt
+++ b/core/settings/TextModeState.kt
@@ -1,0 +1,8 @@
+package com.mewmix.nabu.core.settings
+
+import com.mewmix.nabu.core.tts.TextMode
+
+data class TextModeState(
+    val mode: TextMode = TextMode.AUTO_G2P,
+    val langCode: String = "en-us"
+)

--- a/core/tts/PhonemizerImpl.kt
+++ b/core/tts/PhonemizerImpl.kt
@@ -1,0 +1,110 @@
+package com.mewmix.nabu.core.tts
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
+
+class PhonemizerImpl(
+    private val misaki: MisakiAdapter?,
+    private val espeak: EspeakAdapter?
+) : Phonemizer {
+
+    // Simple lock-free cache; replace with LRU if you want eviction
+    private val cache = ConcurrentHashMap<Int, String>() // key = (mode,lang,hash(input))
+
+    override suspend fun toIpa(input: String, mode: TextMode, cfg: G2PConfig): String =
+        withContext(Dispatchers.Default) {
+            require(input.isNotBlank()) { "Empty input" }
+            require(cfg.langCode.isNotBlank()) { "Missing langCode" }
+
+            val key = (mode.name + "|" + cfg.langCode + "|" + input).hashCode()
+            cache[key]?.let { return@withContext it }
+
+            val out = when (mode) {
+                TextMode.IPA -> {
+                    val norm = normalizeIpa(input)
+                    validateIpa(norm)
+                    norm
+                }
+                TextMode.ARPABET -> {
+                    val ipa = arpabetToIpaSafe(input)
+                    validateIpa(ipa)
+                    ipa
+                }
+                TextMode.AUTO_G2P -> {
+                    val text = normalizeText(input)
+                    val ipa = runG2P(text, cfg)
+                    validateIpa(ipa)
+                    ipa
+                }
+            }
+
+            cache[key] = out
+            out
+        }
+
+    // --- G2P orchestration ---
+    private fun runG2P(text: String, cfg: G2PConfig): String {
+        if (cfg.preferMisaki && misaki?.supports(cfg.langCode) == true) {
+            misaki.g2p(text, cfg.langCode)?.let { return normalizeIpa(it) }
+        }
+        if (cfg.fallbackEspeak && espeak?.supports(cfg.langCode) == true) {
+            espeak.g2pToIpa(text, cfg.langCode)?.let { return normalizeIpa(it) }
+        }
+        throw IllegalStateException("No G2P available for ${cfg.langCode}")
+    }
+
+    // --- Normalizers/validators (fast & strict) ---
+    private fun normalizeText(s: String): String =
+        s.replace('\u2019', '\'')
+         .replace('\u2014', '-')
+         .replace(Regex("\\s+"), " ")
+         .trim()
+
+    private fun normalizeIpa(ipa: String): String =
+        ipa.replace(Regex("\\s+"), " ").trim()
+
+    private fun validateIpa(ipa: String) {
+        val ok = ipa.matches(Regex("""^[a-zA-Zʰʷɾɬɮʃʒɹɲŋɣðθʈɖɟɡɢʔɸβʋɭʎçʝxχʕħʙrʀmɱnɳɴpbdtkgqfvszʂʐhjiueoɑæʊʌɔəɚɝɐɜɞɒːˑˈˌːːː˞˩˨˧˦˥̃ˠˤʲˈˌːˑ ̩ ̯ ̈ ̃ ̊ ̥ ̬ ̹ ̜ ̟ ̠ ̽ .,'-]+$"""))
+        if (!ok) throw IllegalArgumentException("Invalid IPA content")
+    }
+
+    // --- ARPAbet conversion (minimal, extend as needed) ---
+    private fun arpabetToIpaSafe(arpabet: String): String {
+        val map = ARPA_TO_IPA
+        val tokens = arpabet.trim().split(Regex("\\s+"))
+        if (tokens.isEmpty()) throw IllegalArgumentException("Empty ARPAbet")
+
+        val out = buildString {
+            tokens.forEachIndexed { i, t ->
+                val (base, stress) = t.partitionLastDigit()
+                val ipa = map[base] ?: throw IllegalArgumentException("Unknown ARPAbet: $base")
+                append(ipa)
+                when (stress) {
+                    '1' -> append('ˈ')
+                    '2' -> append('ˌ')
+                }
+                if (i != tokens.lastIndex) append(' ')
+            }
+        }
+        return out
+    }
+
+    private fun String.partitionLastDigit(): Pair<String, Char?> {
+        val last = this.last()
+        return if (last.isDigit()) this.dropLast(1) to last else this to null
+    }
+
+    companion object {
+        private val ARPA_TO_IPA = mapOf(
+            "AA" to "ɑ", "AE" to "æ", "AH" to "ʌ", "AO" to "ɔ", "AW" to "aʊ",
+            "AX" to "ə", "AY" to "aɪ", "EH" to "ɛ", "ER" to "ɝ", "EY" to "eɪ",
+            "IH" to "ɪ", "IY" to "i", "OW" to "oʊ", "OY" to "ɔɪ", "UH" to "ʊ", "UW" to "u",
+            "B" to "b", "CH" to "tʃ", "D" to "d", "DH" to "ð", "F" to "f", "G" to "g",
+            "HH" to "h", "JH" to "dʒ", "K" to "k", "L" to "l", "M" to "m", "N" to "n",
+            "NG" to "ŋ", "P" to "p", "R" to "ɹ", "S" to "s", "SH" to "ʃ", "T" to "t",
+            "TH" to "θ", "V" to "v", "W" to "w", "Y" to "j", "Z" to "z", "ZH" to "ʒ"
+        )
+    }
+}
+

--- a/core/tts/PhonemizerImplTest.kt
+++ b/core/tts/PhonemizerImplTest.kt
@@ -1,0 +1,74 @@
+package com.mewmix.nabu.core.tts
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+private class FakeMisaki(
+    private val data: Map<String, String> = emptyMap(),
+    private val supported: Set<String> = emptySet()
+) : MisakiAdapter {
+    override fun supports(langCode: String) = supported.contains(langCode)
+    override fun g2p(text: String, langCode: String) = data[text]
+}
+
+private class FakeEspeak(
+    private val data: Map<String, String> = emptyMap(),
+    private val supported: Set<String> = emptySet()
+) : EspeakAdapter {
+    override fun supports(langCode: String) = supported.contains(langCode)
+    override fun g2pToIpa(text: String, langCode: String) = data[text]
+}
+
+class PhonemizerImplTest {
+    @Test
+    fun autoG2P_misakiFirst() = kotlinx.coroutines.runBlocking {
+        val misaki = FakeMisaki(mapOf("hello" to "hɛlo"), setOf("en-us"))
+        val espeak = FakeEspeak()
+        val phon = PhonemizerImpl(misaki, espeak)
+        val ipa = phon.toIpa("hello", TextMode.AUTO_G2P, G2PConfig("en-us"))
+        assertEquals("hɛlo", ipa)
+    }
+
+    @Test
+    fun autoG2P_fallbackEspeak() = kotlinx.coroutines.runBlocking {
+        val misaki = FakeMisaki(supported = emptySet())
+        val espeak = FakeEspeak(mapOf("hello" to "hɛlo"), setOf("en-us"))
+        val phon = PhonemizerImpl(misaki, espeak)
+        val ipa = phon.toIpa("hello", TextMode.AUTO_G2P, G2PConfig("en-us"))
+        assertEquals("hɛlo", ipa)
+    }
+
+    @Test
+    fun arpabet_basicMap() = kotlinx.coroutines.runBlocking {
+        val phon = PhonemizerImpl(null, null)
+        val ipa = phon.toIpa("HH EH1 L OW0", TextMode.ARPABET, G2PConfig("en-us"))
+        assertEquals("h ˈɛ l oʊ", ipa)
+    }
+
+    @Test
+    fun ipa_rejectBadChars() = kotlinx.coroutines.runBlocking {
+        val phon = PhonemizerImpl(null, null)
+        assertFailsWith<IllegalArgumentException> {
+            phon.toIpa("hello 😊", TextMode.IPA, G2PConfig("en-us"))
+        }
+    }
+
+    @Test
+    fun cache_hit() = kotlinx.coroutines.runBlocking {
+        var calls = 0
+        val misaki = object : MisakiAdapter {
+            override fun supports(langCode: String) = true
+            override fun g2p(text: String, langCode: String): String {
+                calls++
+                return "hɛlo"
+            }
+        }
+        val phon = PhonemizerImpl(misaki, null)
+        val cfg = G2PConfig("en-us")
+        val first = phon.toIpa("hello", TextMode.AUTO_G2P, cfg)
+        val second = phon.toIpa("hello", TextMode.AUTO_G2P, cfg)
+        assertEquals(first, second)
+        assertEquals(1, calls)
+    }
+}

--- a/core/tts/TextMode.kt
+++ b/core/tts/TextMode.kt
@@ -1,0 +1,19 @@
+package com.mewmix.nabu.core.tts
+
+enum class TextMode { AUTO_G2P, IPA, ARPABET }
+
+data class G2PConfig(
+    val langCode: String,
+    val preferMisaki: Boolean = true,
+    val fallbackEspeak: Boolean = true,
+    val maxLen: Int = 2000
+)
+
+interface Phonemizer {
+    /**
+     * Input: raw text (for AUTO_G2P/ARPABET) or IPA (for IPA mode).
+     * Output: normalized IPA string Kokoro expects.
+     */
+    suspend fun toIpa(input: String, mode: TextMode, cfg: G2PConfig): String
+}
+

--- a/core/tts/adapters.kt
+++ b/core/tts/adapters.kt
@@ -1,0 +1,11 @@
+package com.mewmix.nabu.core.tts
+
+interface MisakiAdapter {
+    fun supports(langCode: String): Boolean
+    fun g2p(text: String, langCode: String): String?
+}
+
+interface EspeakAdapter {
+    fun supports(langCode: String): Boolean
+    fun g2pToIpa(text: String, langCode: String): String?
+}

--- a/engine/kokoro/KokoroRunner.kt
+++ b/engine/kokoro/KokoroRunner.kt
@@ -1,0 +1,25 @@
+package com.mewmix.nabu.engine.kokoro
+
+import com.mewmix.nabu.core.settings.TextModeState
+import com.mewmix.nabu.core.tts.G2PConfig
+import com.mewmix.nabu.core.tts.Phonemizer
+
+class AudioBuffer
+
+interface KokoroFrontend {
+    fun generateFromIpa(ipa: String): AudioBuffer
+}
+
+suspend fun synthesize(
+    rawInput: String,
+    textModeState: TextModeState,
+    phonemizer: Phonemizer,
+    kokoro: KokoroFrontend
+): AudioBuffer {
+    val ipa = phonemizer.toIpa(
+        input = rawInput,
+        mode = textModeState.mode,
+        cfg = G2PConfig(langCode = textModeState.langCode)
+    )
+    return kokoro.generateFromIpa(ipa)
+}


### PR DESCRIPTION
## Summary
- add TextMode enums, configuration, and Phonemizer interface
- implement PhonemizerImpl with caching, validation, ARPAbet conversion, and misaki/espeak fallback
- provide adapters, settings state, Kokoro runner integration, and unit tests

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a119ff762483319fcb5120bbb31796