### PR TITLE
Add eSpeak-NG phonemizer for Kitten TTS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,18 @@ android {
         }
     }
 
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
+    }
+
+    sourceSets {
+        getByName("main") {
+            jniLibs.srcDirs("src/main/jniLibs")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+project(espeakng_jni)
+
+add_library(espeakng_jni SHARED espeakng_jni.c)
+
+# Attempt to link against a prebuilt eSpeak NG shared library if present.
+find_library(espeak_ng_lib NAMES espeak-ng PATHS ${CMAKE_SOURCE_DIR}/../jniLibs/arm64-v8a)
+if(espeak_ng_lib)
+    target_link_libraries(espeakng_jni ${espeak_ng_lib} log)
+else()
+    message(WARNING "eSpeak-NG library not found; building stub JNI only")
+    target_link_libraries(espeakng_jni log)
+endif()

--- a/app/src/main/cpp/espeakng_jni.c
+++ b/app/src/main/cpp/espeakng_jni.c
@@ -1,0 +1,46 @@
+#include <jni.h>
+#include <string.h>
+#include <pthread.h>
+#include "espeak-ng/speak_lib.h"
+
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+static int g_inited = 0;
+
+static void ensure_init() {
+    if (g_inited) return;
+    int samplerate = espeak_Initialize(AUDIO_OUTPUT_SYNCHRONOUS, 0, NULL, 0);
+    (void)samplerate;
+    espeak_SetParameter(espeakSSML, 1, 0);
+    g_inited = 1;
+}
+
+JNIEXPORT jstring JNICALL
+Java_com_mewmix_nabu_core_tts_EspeakNgAdapter_nativeG2pToIpa(
+        JNIEnv* env, jobject thiz, jstring jtext, jstring jlang) {
+    const char* text = (*env)->GetStringUTFChars(env, jtext, 0);
+    const char* lang = (*env)->GetStringUTFChars(env, jlang, 0);
+
+    pthread_mutex_lock(&g_lock);
+    ensure_init();
+
+    espeak_VOICE v = {0};
+    v.languages = (char*)lang;
+    v.name = NULL;
+    v.variant = 0;
+    v.age = 0;
+    espeak_SetVoiceByProperties(&v);
+
+    espeak_SetPhonemeTrace(0x20 | 0x08 | 0x01);
+
+    char* out = espeak_TextToPhonemes((const void*)text, espeakCHARS_UTF8, 0x20);
+
+    jstring result = NULL;
+    if (out && strlen(out) > 0) {
+        result = (*env)->NewStringUTF(env, out);
+    }
+
+    pthread_mutex_unlock(&g_lock);
+    (*env)->ReleaseStringUTFChars(env, jtext, text);
+    (*env)->ReleaseStringUTFChars(env, jlang, lang);
+    return result;
+}

--- a/app/src/main/java/com/example/nabu/utils/KittenPhonemizer.kt
+++ b/app/src/main/java/com/example/nabu/utils/KittenPhonemizer.kt
@@ -1,27 +1,36 @@
 package com.example.nabu.utils
 
-import com.agent.kitten.KittenPhonemizerStatic
+import com.mewmix.nabu.core.tts.G2PConfig
+import com.mewmix.nabu.core.tts.Phonemizer
+import com.mewmix.nabu.core.tts.TextMode
+import com.mewmix.nabu.core.tts.EspeakNgAdapter
+import com.mewmix.nabu.kitten.KittenTextPolicy
+import com.mewmix.nabu.kitten.KittenTokenizer
+import kotlinx.coroutines.runBlocking
 
 object KittenPhonemizer {
     private const val MAX_PHONEME_LENGTH = 400
 
-    private val VOCAB: Map<Char, Int>
+    private val VOCAB: Map<String, Int>
 
     init {
         val pad = '$'
         val punctuation = ";:,.!?¡¿—…\"«»“” "
         val letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-        val lettersIpa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩'ᵻ"
+        val lettersIpa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗"
         val symbols = listOf(pad) + punctuation.toList() + letters.toList() + lettersIpa.toList()
-        VOCAB = symbols.withIndex().associate { (index, char) -> char to index }
+        VOCAB = symbols.withIndex().associate { (index, char) -> char.toString() to index }
     }
 
-    fun phonemize(text: String): Pair<String, LongArray> {
-        val phonemeStr = KittenPhonemizerStatic.phonemize(text)
-        val truncated = phonemeStr.take(MAX_PHONEME_LENGTH)
-        val tokens = truncated.map { ch ->
-            VOCAB[ch] ?: throw IllegalArgumentException("Kitten TTS: Unknown symbol '$ch'")
-        }
+    private val tokenizer = KittenTokenizer(VOCAB, unkId = 0)
+    private val phonemizer: Phonemizer = KittenTextPolicy(
+        EspeakNgAdapter(setOf("en-us", "en-gb", "es", "fr", "de", "it", "pt", "ru", "ja", "zh"))
+    )
+
+    fun phonemize(text: String, lang: String = "en-us"): Pair<String, LongArray> {
+        val ipa = runBlocking { phonemizer.toIpa(text, TextMode.AUTO_G2P, G2PConfig(lang)) }
+        val truncated = ipa.take(MAX_PHONEME_LENGTH)
+        val tokens = tokenizer.encode(truncated)
         val padded = LongArray(tokens.size + 2)
         padded[0] = 0L
         tokens.forEachIndexed { index, value -> padded[index + 1] = value.toLong() }

--- a/app/src/main/java/com/mewmix/nabu/core/tts/EspeakAdapter.kt
+++ b/app/src/main/java/com/mewmix/nabu/core/tts/EspeakAdapter.kt
@@ -1,0 +1,12 @@
+package com.mewmix.nabu.core.tts
+
+/**
+ * Minimal abstraction over an eSpeak-NG backed phonemizer.
+ */
+interface EspeakAdapter {
+    /** Returns true if the adapter has a voice for the given language code. */
+    fun supports(langCode: String): Boolean
+
+    /** Converts the supplied text into IPA for the requested language. */
+    fun g2pToIpa(text: String, langCode: String): String?
+}

--- a/app/src/main/java/com/mewmix/nabu/core/tts/EspeakNgAdapter.kt
+++ b/app/src/main/java/com/mewmix/nabu/core/tts/EspeakNgAdapter.kt
@@ -1,0 +1,21 @@
+package com.mewmix.nabu.core.tts
+
+/**
+ * JNI backed adapter that talks to eSpeak-NG for grapheme to IPA conversion.
+ */
+class EspeakNgAdapter(
+    private val availableVoices: Set<String>
+) : EspeakAdapter {
+    init {
+        // Load the native JNI bridge which internally links against eSpeak-NG.
+        System.loadLibrary("espeakng_jni")
+    }
+
+    override fun supports(langCode: String): Boolean =
+        availableVoices.contains(langCode.lowercase())
+
+    override fun g2pToIpa(text: String, langCode: String): String? =
+        nativeG2pToIpa(text, langCode.lowercase())
+
+    private external fun nativeG2pToIpa(text: String, lang: String): String?
+}

--- a/app/src/main/java/com/mewmix/nabu/core/tts/Phonemizer.kt
+++ b/app/src/main/java/com/mewmix/nabu/core/tts/Phonemizer.kt
@@ -1,0 +1,21 @@
+package com.mewmix.nabu.core.tts
+
+/**
+ * Basic phonemizer contract for converting text to IPA.
+ */
+interface Phonemizer {
+    suspend fun toIpa(input: String, mode: TextMode, cfg: G2PConfig): String
+}
+
+/**
+ * Text input mode for the phonemizer.
+ */
+enum class TextMode {
+    IPA,
+    AUTO_G2P
+}
+
+/**
+ * Configuration for grapheme-to-phoneme conversion.
+ */
+data class G2PConfig(val langCode: String)

--- a/app/src/main/java/com/mewmix/nabu/kitten/KittenTextPolicy.kt
+++ b/app/src/main/java/com/mewmix/nabu/kitten/KittenTextPolicy.kt
@@ -1,0 +1,38 @@
+package com.mewmix.nabu.kitten
+
+import com.mewmix.nabu.core.tts.*
+
+/**
+ * Kitten specific text policy that always routes through eSpeak-NG.
+ */
+class KittenTextPolicy(
+    private val espeak: EspeakAdapter
+) : Phonemizer {
+
+    private val impl = object : Phonemizer {
+        override suspend fun toIpa(input: String, mode: TextMode, cfg: G2PConfig): String {
+            require(mode != TextMode.IPA) { "Kitten expects controlled IPA; user-IPA disabled for Kitten" }
+            require(espeak.supports(cfg.langCode)) { "eSpeak has no voice for ${cfg.langCode}" }
+            val text = normalizeText(input)
+            val ipa = espeak.g2pToIpa(text, cfg.langCode) ?: error("eSpeak returned null")
+            val norm = normalizeIpa(ipa)
+            validateIpa(norm)
+            return norm
+        }
+    }
+
+    override suspend fun toIpa(input: String, mode: TextMode, cfg: G2PConfig): String =
+        impl.toIpa(input, TextMode.AUTO_G2P, cfg)
+
+    private fun normalizeText(s: String) =
+        s.replace('\u2019','\'').replace('\u2014','-').replace(Regex("\\s+")," ").trim()
+
+    private fun normalizeIpa(ipa: String) =
+        ipa.replace(Regex("\\s+")," ").trim()
+
+    private fun validateIpa(ipa: String) {
+        // reuse your Kokoro validator; Kitten uses similar inventory
+        if (!ipa.matches(Regex("""^[\\p{L}\\p{M}\\p{Zs}\\p{Punct}ˈˌːˑ̃˞˩˨˧˦˥ɪɛæɑɔʊə…-]+$""")))
+            error("Invalid IPA content for Kitten")
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/kitten/KittenTokenizer.kt
+++ b/app/src/main/java/com/mewmix/nabu/kitten/KittenTokenizer.kt
@@ -1,0 +1,21 @@
+package com.mewmix.nabu.kitten
+
+/**
+ * Simple tokenizer turning IPA characters into token ids using a fixed map.
+ */
+class KittenTokenizer(
+    ipaToId: Map<String, Int>,
+    private val unkId: Int
+) {
+    private val map = ipaToId
+
+    fun encode(ipa: String): IntArray {
+        val chars = ipa.toCharArray()
+        val out = IntArray(chars.size)
+        var i = 0
+        for (c in chars) {
+            out[i++] = map[c.toString()] ?: unkId
+        }
+        return out
+    }
+}


### PR DESCRIPTION
## Summary
- integrate eSpeak-NG JNI bridge and adapter
- introduce Kitten text policy and tokenizer
- route KittenPhonemizer through eSpeak and native IPA generation
- wire CMake and Gradle configs for native library build

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11f5a8b308331be66206303d95f1c