### PR TITLE
Style dropdown settings with Brutalist UI

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -13,14 +13,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
@@ -31,6 +28,8 @@ import com.example.nabu.ui.components.ProgressDialog
 import com.example.nabu.viewmodel.BookViewModel
 import kotlinx.coroutines.launch
 import com.mewmix.nabu.ui.brutalist.PanelBox
+import com.mewmix.nabu.ui.brutalist.BrutalSection
+import com.mewmix.nabu.ui.brutalist.Brutal
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
@@ -136,144 +135,119 @@ fun BookScreen(
             state = listState
         ) {
         item {
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { showSettings = !showSettings },
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text("Settings", style = MaterialTheme.typography.titleMedium)
-                        Spacer(modifier = Modifier.weight(1f))
-                        Icon(
-                            imageVector = Icons.Default.ArrowDropDown,
-                            contentDescription = "Toggle Settings",
-                            modifier = Modifier.graphicsLayer(rotationZ = if (showSettings) 180f else 0f)
-                        )
+            BrutalSection(
+                title = "Settings",
+                expanded = showSettings,
+                onToggle = { showSettings = !showSettings }
+            ) {
+                StyleSelector(
+                    styleNames = styleLoader.names,
+                    selectedStyles = selectedStyles,
+                    onAddStyle = { style ->
+                        selectedStyles = selectedStyles + style
+                        weights = weights + (style to 1f)
+                    },
+                    onRemoveStyle = { style ->
+                        selectedStyles = selectedStyles - style
+                        weights = weights - style
                     }
-                    if (showSettings) {
-                        Divider(modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.padding_medium)))
-                        StyleSelector(
-                            styleNames = styleLoader.names,
-                            selectedStyles = selectedStyles,
-                            onAddStyle = { style ->
-                                selectedStyles = selectedStyles + style
-                                weights = weights + (style to 1f)
-                            },
-                            onRemoveStyle = { style ->
-                                selectedStyles = selectedStyles - style
-                                weights = weights - style
-                            }
-                        )
-                        WeightSliders(
-                            selectedStyles = selectedStyles,
-                            weights = weights,
-                            onWeightChanged = { style, value ->
-                                weights = weights.toMutableMap().apply { put(style, value) }
-                            }
-                        )
-                        InterpolationModeSelector(
-                            currentMode = interpolationMode,
-                            onModeSelected = { interpolationMode = it }
-                        )
-                        Text("Speed: ${ "%.2f".format(speed)}", style = MaterialTheme.typography.bodyMedium)
-                        Slider(
-                            value = speed,
-                            onValueChange = {
-                                speed = it
-                                SettingsManager.setSpeed(context, it)
-                            },
-                            valueRange = 0.5f..2.0f,
-                            steps = 15,
-                            modifier = Modifier.fillMaxWidth()
-                        )
+                )
+                WeightSliders(
+                    selectedStyles = selectedStyles,
+                    weights = weights,
+                    onWeightChanged = { style, value ->
+                        weights = weights.toMutableMap().apply { put(style, value) }
                     }
-                }
+                )
+                InterpolationModeSelector(
+                    currentMode = interpolationMode,
+                    onModeSelected = { interpolationMode = it }
+                )
+                Text(
+                    "Speed: ${ "%.2f".format(speed)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Brutal.textBright,
+                    fontFamily = Brutal.mono
+                )
+                Slider(
+                    value = speed,
+                    onValueChange = {
+                        speed = it
+                        SettingsManager.setSpeed(context, it)
+                    },
+                    valueRange = 0.5f..2.0f,
+                    steps = 15,
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         }
 
         item {
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { showProjectSection = !showProjectSection },
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text("Projects", style = MaterialTheme.typography.titleMedium)
-                        Spacer(modifier = Modifier.weight(1f))
-                        Icon(
-                            imageVector = Icons.Default.ArrowDropDown,
-                            contentDescription = "Toggle Projects",
-                            modifier = Modifier.graphicsLayer(rotationZ = if (showProjectSection) 180f else 0f)
-                        )
-                    }
-                    if (showProjectSection) {
-                        Divider(modifier = Modifier.padding(vertical = dimensionResource(id = R.dimen.padding_medium)))
-                        OutlinedTextField(
-                            value = projectName,
-                            onValueChange = { projectName = it },
-                            label = { Text("Project Name") },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
-                        ) {
-                            Text("Use Pregenerated")
-                            Spacer(modifier = Modifier.weight(1f))
-                            Switch(checked = usePregenerated, onCheckedChange = { usePregenerated = it })
+            BrutalSection(
+                title = "Projects",
+                expanded = showProjectSection,
+                onToggle = { showProjectSection = !showProjectSection }
+            ) {
+                OutlinedTextField(
+                    value = projectName,
+                    onValueChange = { projectName = it },
+                    label = { Text("Project Name") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
+                ) {
+                    Text("Use Pregenerated", color = Brutal.textBright, fontFamily = Brutal.mono)
+                    Spacer(modifier = Modifier.weight(1f))
+                    Switch(checked = usePregenerated, onCheckedChange = { usePregenerated = it })
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_small)),
+                    modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
+                ) {
+                    Button(onClick = {
+                        bookUri?.let {
+                            val project = Project(
+                                uri = it.toString(),
+                                name = projectName,
+                                styles = selectedStyles,
+                                weights = weights,
+                                mode = interpolationMode,
+                                speed = speed,
+                                bookmark = bookmark,
+                                usePregenerated = usePregenerated
+                            )
+                            ProjectManager.save(context, project)
+                            projects = ProjectManager.list(context)
                         }
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_small)),
-                            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
-                        ) {
-                            Button(onClick = {
-                                bookUri?.let {
-                                    val project = Project(
-                                        uri = it.toString(),
-                                        name = projectName,
-                                        styles = selectedStyles,
-                                        weights = weights,
-                                        mode = interpolationMode,
-                                        speed = speed,
-                                        bookmark = bookmark,
-                                        usePregenerated = usePregenerated
-                                    )
-                                    ProjectManager.save(context, project)
-                                    projects = ProjectManager.list(context)
-                                }
-                            }) { Text("Save Project") }
-                            Button(onClick = {
-                                bookUri?.let {
-                                    ProjectManager.delete(context, it.toString())
-                                    projects = ProjectManager.list(context)
-                                    projectName = ""
-                                }
-                            }) { Text("Delete Project") }
+                    }) { Text("Save Project") }
+                    Button(onClick = {
+                        bookUri?.let {
+                            ProjectManager.delete(context, it.toString())
+                            projects = ProjectManager.list(context)
+                            projectName = ""
                         }
-                        if (projects.isNotEmpty()) {
-                            Divider(modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small)))
-                            Column(modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))) {
-                                projects.forEach { p ->
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.fillMaxWidth()
-                                    ) {
-                                        Text(p.name, modifier = Modifier.weight(1f))
-                                        Button(onClick = {
-                                            val uri = Uri.parse(p.uri)
-                                            bookViewModel.openDocument(uri)
-                                            bookViewModel.loadBook(context, uri)
-                                        }) { Text("Load") }
-                                        Button(onClick = {
-                                            ProjectManager.delete(context, p.uri)
-                                            projects = ProjectManager.list(context)
-                                        }) { Text("Del") }
-                                    }
-                                }
+                    }) { Text("Delete Project") }
+                }
+                if (projects.isNotEmpty()) {
+                    Divider(modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small)))
+                    Column(modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))) {
+                        projects.forEach { p ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(p.name, modifier = Modifier.weight(1f), color = Brutal.textBright, fontFamily = Brutal.mono)
+                                Button(onClick = {
+                                    val uri = Uri.parse(p.uri)
+                                    bookViewModel.openDocument(uri)
+                                    bookViewModel.loadBook(context, uri)
+                                }) { Text("Load") }
+                                Button(onClick = {
+                                    ProjectManager.delete(context, p.uri)
+                                    projects = ProjectManager.list(context)
+                                }) { Text("Del") }
                             }
                         }
                     }

--- a/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
@@ -19,12 +19,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Send
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -47,6 +44,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mewmix.nabu.ui.brutalist.PanelBox
+import com.mewmix.nabu.ui.brutalist.BrutalSection
+import com.mewmix.nabu.ui.brutalist.Brutal
 import com.example.kokoro.chat.MessageBubble
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PcmTap
@@ -111,59 +110,41 @@ fun ChatTtsScreen(
                 .padding(paddingValues)
         ) {
 
-            // Mixer Settings in a Card
-            Card(
+            BrutalSection(
+                title = "Voice Mixer Settings",
+                expanded = showMixerSettings,
+                onToggle = { showMixerSettings = !showMixerSettings },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(8.dp),
+                    .padding(8.dp)
             ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { showMixerSettings = !showMixerSettings },
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            "Voice Mixer Settings",
-                            style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        Icon(
-                            imageVector = if (showMixerSettings) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                            contentDescription = if (showMixerSettings) "Collapse" else "Expand",
-                        )
-                    }
-                    if (showMixerSettings) {
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                            StyleSelector(
-                                styleNames = viewModel.styleLoader.names,
-                                selectedStyles = selectedStyles,
-                                onAddStyle = viewModel::addStyle,
-                                onRemoveStyle = viewModel::removeStyle,
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            WeightSliders(
-                                selectedStyles = selectedStyles,
-                                weights = weights,
-                                onWeightChanged = viewModel::updateWeight,
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            InterpolationModeSelector(
-                                currentMode = interpolationMode,
-                                onModeSelected = viewModel::updateInterpolationMode,
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text("Speed: ${"%.2f".format(speed)}")
-                            Slider(
-                                value = speed,
-                                onValueChange = { viewModel.updateSpeed(it) },
-                                valueRange = 0.5f..2.0f,
-                                steps = 15,
-                            )
-                        }
-                    }
+                Spacer(modifier = Modifier.height(8.dp))
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    StyleSelector(
+                        styleNames = viewModel.styleLoader.names,
+                        selectedStyles = selectedStyles,
+                        onAddStyle = viewModel::addStyle,
+                        onRemoveStyle = viewModel::removeStyle,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    WeightSliders(
+                        selectedStyles = selectedStyles,
+                        weights = weights,
+                        onWeightChanged = viewModel::updateWeight,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    InterpolationModeSelector(
+                        currentMode = interpolationMode,
+                        onModeSelected = viewModel::updateInterpolationMode,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("Speed: ${"%.2f".format(speed)}", color = Brutal.textBright, fontFamily = Brutal.mono)
+                    Slider(
+                        value = speed,
+                        onValueChange = { viewModel.updateSpeed(it) },
+                        valueRange = 0.5f..2.0f,
+                        steps = 15,
+                    )
                 }
             }
 

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -1,5 +1,7 @@
 package com.example.nabu.screens
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,16 +21,19 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.RadioButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SuggestionChipDefaults
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -40,8 +45,11 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import com.mewmix.nabu.ui.brutalist.Brutal
 import com.mewmix.nabu.ui.brutalist.PanelBox
 import com.example.nabu.utils.InterpolationMode
 import com.example.nabu.utils.PhonemeConverter
@@ -290,7 +298,6 @@ private fun saveStyleConfig(
         .apply()
 }
 
-
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun StyleSelector(
@@ -302,7 +309,12 @@ fun StyleSelector(
     var expanded by remember { mutableStateOf(false) }
 
     Column {
-        Text("Selected Styles:", style = MaterialTheme.typography.labelLarge)
+        Text(
+            "Selected Styles:",
+            style = MaterialTheme.typography.labelLarge,
+            color = Brutal.textBright,
+            fontFamily = Brutal.mono
+        )
 
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
@@ -311,13 +323,19 @@ fun StyleSelector(
             selectedStyles.forEach { style ->
                 SuggestionChip(
                     onClick = { onRemoveStyle(style) },
-                    label = { Text(style) },
+                    label = { Text(style, color = Brutal.textBright, fontFamily = Brutal.mono) },
                     icon = {
                         Icon(
                             Icons.Default.Close,
-                            contentDescription = "Remove"
+                            contentDescription = "Remove",
+                            tint = Brutal.textBright
                         )
-                    }
+                    },
+                    colors = SuggestionChipDefaults.suggestionChipColors(
+                        containerColor = Brutal.panelBg,
+                        iconContentColor = Brutal.textBright,
+                        labelColor = Brutal.textBright
+                    )
                 )
             }
         }
@@ -332,29 +350,54 @@ fun StyleSelector(
                 value = "",
                 onValueChange = {},
                 readOnly = true,
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                placeholder = { Text("Add style...") },
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.ArrowDropDown,
+                        contentDescription = null,
+                        tint = Brutal.textBright,
+                        modifier = Modifier.graphicsLayer(rotationZ = if (expanded) 180f else 0f)
+                    )
+                },
+                placeholder = { Text("Add style...", color = Brutal.textDim, fontFamily = Brutal.mono) },
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Brutal.panelBg,
+                    unfocusedContainerColor = Brutal.panelBg,
+                    focusedIndicatorColor = Brutal.hairline,
+                    unfocusedIndicatorColor = Brutal.hairline,
+                    cursorColor = Brutal.amber,
+                    focusedTextColor = Brutal.textBright,
+                    unfocusedTextColor = Brutal.textBright,
+                    focusedPlaceholderColor = Brutal.textDim,
+                    unfocusedPlaceholderColor = Brutal.textDim
+                ),
+                textStyle = MaterialTheme.typography.bodyLarge.copy(fontFamily = Brutal.mono),
                 modifier = Modifier
                     .menuAnchor()
                     .fillMaxWidth()
+                    .border(1.dp, Brutal.hairline, RoundedCornerShape(4.dp))
             )
 
             DropdownMenu(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onDismissRequest = { expanded = false },
+                modifier = Modifier
+                    .background(Brutal.panelBg)
+                    .border(1.dp, Brutal.hairline, RoundedCornerShape(4.dp))
             ) {
                 styleNames.filter { it !in selectedStyles }.forEach { style ->
                     DropdownMenuItem(
-                        text = { Text(style) },
+                        text = { Text(style, color = Brutal.textBright, fontFamily = Brutal.mono) },
                         onClick = {
                             onAddStyle(style)
                             expanded = false
-                        }
+                        },
+                        colors = MenuDefaults.itemColors(textColor = Brutal.textBright)
                     )
                 }
             }
         }
     }
+}
 }
 
 @Composable

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -398,7 +398,6 @@ fun StyleSelector(
         }
     }
 }
-}
 
 @Composable
 fun WeightSliders(

--- a/app/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
+++ b/app/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
@@ -9,7 +9,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -21,6 +26,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
@@ -89,6 +95,52 @@ fun PanelBox(
             if (headerTrailing != null) Row(content = headerTrailing)
         }
         content()
+    }
+}
+
+/* ---------- Collapsible Section ---------- */
+@Composable
+fun BrutalSection(
+    title: String,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .background(Brutal.panelHl, RoundedCornerShape(6.dp))
+            .border(1.dp, Brutal.panelStroke, RoundedCornerShape(6.dp))
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onToggle() },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                title,
+                color = Brutal.textBright,
+                style = MaterialTheme.typography.titleMedium,
+                fontFamily = Brutal.mono
+            )
+            Spacer(Modifier.weight(1f))
+            Icon(
+                imageVector = Icons.Default.ArrowDropDown,
+                contentDescription = "Toggle $title",
+                tint = Brutal.textBright,
+                modifier = Modifier.graphicsLayer(rotationZ = if (expanded) 180f else 0f)
+            )
+        }
+        if (expanded) {
+            Divider(
+                color = Brutal.hairline,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+            content()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add reusable `BrutalSection` for collapsible brutalist panels
- restyle voice style selector and dropdown menus with brutalist palette
- replace Book and Chat TTS settings cards with brutalist sections for consistent UI

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fb666fd483319308cd84a7a1f62b