### PR TITLE
feat: add radial waveform to book activity

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.nabu.R
 import com.example.nabu.utils.*
 import com.example.nabu.ui.components.ProgressDialog
+import com.example.nabu.ui.components.RadialWaveformVisualizer
 import com.example.nabu.viewmodel.BookViewModel
 import kotlinx.coroutines.launch
 import com.mewmix.nabu.ui.brutalist.PanelBox
@@ -32,6 +33,7 @@ import com.mewmix.nabu.ui.brutalist.BrutalSection
 import com.mewmix.nabu.ui.brutalist.Brutal
 import com.mewmix.nabu.ui.brutalist.BrutalButton
 import com.mewmix.nabu.ui.brutalist.BrutalSlider
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
@@ -123,6 +125,10 @@ fun BookScreen(
         if (currentLine >= 0) {
             listState.animateScrollToItem(currentLine)
         }
+    }
+
+    LaunchedEffect(playerState) {
+        PcmTap.enabled = playerState == PlayerState.PLAYING
     }
 
     PanelBox(
@@ -489,6 +495,15 @@ fun BookScreen(
                     Text(if (isPregenerating) "Pre-generating..." else "Pregenerate")
                 }
             }
+        }
+
+        item {
+            RadialWaveformVisualizer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(150.dp),
+                visible = playerState == PlayerState.PLAYING
+            )
         }
 
         itemsIndexed(lines) { index, line ->

--- a/app/src/main/java/com/example/nabu/ui/components/RadialWaveformVisualizer.kt
+++ b/app/src/main/java/com/example/nabu/ui/components/RadialWaveformVisualizer.kt
@@ -1,0 +1,67 @@
+package com.example.nabu.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.StrokeCap
+import com.example.nabu.utils.PcmTap
+import kotlinx.coroutines.delay
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+/**
+ * Radial waveform visualizer that draws audio samples in a polar layout.
+ */
+@Composable
+fun RadialWaveformVisualizer(
+    modifier: Modifier = Modifier,
+    sampleCount: Int = 1024,
+    lineColor: Color = Color.White,
+    visible: Boolean = true,
+) {
+    var samples by remember { mutableStateOf(FloatArray(sampleCount)) }
+    LaunchedEffect(visible) {
+        while (visible) {
+            if (PcmTap.enabled) {
+                samples = PcmTap.getLastSamples(sampleCount)
+            }
+            delay(16)
+        }
+    }
+
+    AnimatedVisibility(visible) {
+        Canvas(modifier = modifier) {
+            val center = Offset(size.width / 2f, size.height / 2f)
+            val radius = min(size.width, size.height) / 2f
+            val path = Path()
+            val step = (2 * PI) / sampleCount
+            for (i in 0 until sampleCount) {
+                val angle = i * step
+                val amplitude = (samples[i].coerceIn(-1f, 1f) + 1f) / 2f
+                val r = radius * amplitude
+                val x = center.x + cos(angle).toFloat() * r
+                val y = center.y + sin(angle).toFloat() * r
+                if (i == 0) {
+                    path.moveTo(x, y)
+                } else {
+                    path.lineTo(x, y)
+                }
+            }
+            path.close()
+            drawPath(path, color = lineColor, style = Stroke(width = 2f, cap = StrokeCap.Round))
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add radial waveform visualizer component for polar audio display
- show radial waveform during book playback and enable PCM tapping when playing

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22465f76083318669d98237813e41