### PR TITLE
Remove activity titles and top bars

### DIFF
--- a/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
+++ b/app-chat/src/main/java/com/example/kokoro/chat/ChatScreen.kt
@@ -14,19 +14,14 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -42,26 +37,13 @@ import com.mewmix.nabu.ui.brutalist.BrutalButton
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatScreen(
-    viewModel: ChatViewModel,
-    modelName: String,
-    onBackPressed: () -> Unit
+    viewModel: ChatViewModel
 ) {
     val chatState by viewModel.chatState.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     var message by remember { mutableStateOf("") }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("$modelName Chat") },
-                navigationIcon = {
-                    IconButton(onClick = onBackPressed) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                }
-            )
-        }
-    ) { paddingValues ->
+    Scaffold { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/example/nabu/ChatTtsActivity.kt
+++ b/app/src/main/java/com/example/nabu/ChatTtsActivity.kt
@@ -82,7 +82,7 @@ class ChatTtsActivity : ComponentActivity() {
 
         setContent {
             NabuTheme {
-                ChatTtsScreen(viewModel = viewModel, modelName = model.name, onBackPressed = { finish() })
+                ChatTtsScreen(viewModel = viewModel)
                 if (SettingsManager.isBenchmark(this@ChatTtsActivity)) {
                     PerfHud.Overlay()
                 }

--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -55,7 +55,6 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.CenterAlignedTopAppBar
 import com.mewmix.nabu.ui.brutalist.PanelBox
 import com.mewmix.nabu.ui.brutalist.BrutalButton
 import androidx.compose.runtime.Composable
@@ -311,17 +310,17 @@ private fun screenFromString(name: String?): Screen = when (name) {
     else -> Screen.Basic
 }
 
-sealed class Screen(val title: String) {
-    object Basic : Screen("Basic TTS")
-    object Mixer : Screen("Mixer")
-    object Book : Screen("Audio Book")
-    object ChatTts : Screen("Chat TTS") // New screen state for ChatTtsActivity if needed for selection
-    object More : Screen("More")
-    object Creations : Screen("Creations")
-    object Settings : Screen("Settings")
-    object Models : Screen("Models")
-    object DebugLog : Screen("Debug Log")
-    object Credits : Screen("Credits")
+sealed class Screen {
+    object Basic : Screen()
+    object Mixer : Screen()
+    object Book : Screen()
+    object ChatTts : Screen() // New screen state for ChatTtsActivity if needed for selection
+    object More : Screen()
+    object Creations : Screen()
+    object Settings : Screen()
+    object Models : Screen()
+    object DebugLog : Screen()
+    object Credits : Screen()
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -337,11 +336,6 @@ fun MainScreen(
     val context = LocalContext.current
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text(currentScreen.title) }
-            )
-        },
         bottomBar = {
             NavigationBar {
                 NavigationBarItem(
@@ -448,7 +442,6 @@ fun BasicScreen(
     var engineExpanded by remember { mutableStateOf(false) }
 
     PanelBox(
-        title = "Basic · TTS",
         modifier = Modifier
             .padding(16.dp)
             .fillMaxSize()

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -132,7 +132,6 @@ fun BookScreen(
     }
 
     PanelBox(
-        title = "Book · Reader",
         modifier = Modifier
             .fillMaxSize()
             .padding(dimensionResource(id = R.dimen.padding_large))

--- a/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
@@ -15,23 +15,17 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Send
-import androidx.compose.material.icons.filled.VolumeOff
-import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -55,15 +49,12 @@ import com.example.nabu.ui.components.WaveformVisualizer
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChatTtsScreen(
-    viewModel: ChatTtsViewModel,
-    modelName: String,
-    onBackPressed: () -> Unit
+    viewModel: ChatTtsViewModel
 ) {
     val chatMessages by viewModel.chatMessages.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val isSynthesizing by viewModel.isSynthesizing.collectAsState()
     val playerState by viewModel.playerState.collectAsState()
-    val ttsEnabled by viewModel.ttsEnabled.collectAsState()
 
     LaunchedEffect(playerState) {
         PcmTap.enabled = playerState == PlayerState.PLAYING
@@ -84,27 +75,8 @@ fun ChatTtsScreen(
         }
     }
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("$modelName Chat & TTS") },
-                navigationIcon = {
-                    IconButton(onClick = onBackPressed) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                actions = {
-                    IconButton(onClick = { viewModel.toggleTtsEnabled() }) {
-                        val icon = if (ttsEnabled) Icons.Filled.VolumeUp else Icons.Filled.VolumeOff
-                        val desc = if (ttsEnabled) "Disable TTS" else "Enable TTS"
-                        Icon(icon, contentDescription = desc)
-                    }
-                }
-            )
-        }
-    ) { paddingValues ->
+    Scaffold { paddingValues ->
         PanelBox(
-            title = "Chat · TTS",
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -108,7 +108,6 @@ fun MixerScreen(
     var interpolationMode by remember { mutableStateOf(initial.third) }
 
     PanelBox(
-        title = "Mixer · Styles",
         modifier = Modifier
             .padding(16.dp)
             .fillMaxSize()

--- a/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
+++ b/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
@@ -64,7 +64,7 @@ private val BevelStroke = Stroke(width = 1.5f)
 /* ---------- Panel Box (container) ---------- */
 @Composable
 fun PanelBox(
-    title: String,
+    title: String? = null,
     modifier: Modifier = Modifier,
     inset: Dp = 8.dp,
     headerTrailing: (@Composable RowScope.() -> Unit)? = null,
@@ -77,22 +77,34 @@ fun PanelBox(
             .drawBehind {
                 // subtle panel ribs / gridlines:
                 val step = 12f
-                drawRect(Brush.linearGradient(listOf(Color.Transparent, Brutal.panelHl.copy(alpha = 0.08f))), blendMode = BlendMode.SrcOver)
+                drawRect(
+                    Brush.linearGradient(
+                        listOf(Color.Transparent, Brutal.panelHl.copy(alpha = 0.08f))
+                    ),
+                    blendMode = BlendMode.SrcOver
+                )
                 for (y in 0..(size.height / step).toInt()) {
-                    drawLine(Brutal.hairline.copy(alpha = 0.15f), Offset(0f, y * step), Offset(size.width, y * step), 1f)
+                    drawLine(
+                        Brutal.hairline.copy(alpha = 0.15f),
+                        Offset(0f, y * step),
+                        Offset(size.width, y * step),
+                        1f
+                    )
                 }
             }
             .padding(inset)
     ) {
-        Row(
-            Modifier
-                .fillMaxWidth()
-                .padding(bottom = 6.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            LabelPlate(title)
-            Spacer(Modifier.weight(1f))
-            if (headerTrailing != null) Row(content = headerTrailing)
+        if (!title.isNullOrBlank()) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                LabelPlate(title)
+                Spacer(Modifier.weight(1f))
+                if (headerTrailing != null) Row(content = headerTrailing)
+            }
         }
         content()
     }


### PR DESCRIPTION
## Summary
- Allow `PanelBox` to render without a header when no title is supplied.
- Drop top app bars and page titles from Chat, Chat TTS, Book, Mixer and main screens.

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23f8163948331b76ea11df92be831