### PR TITLE
Unify “More” section screens with Brutalist UI kit

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/CreationsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/CreationsScreen.kt
@@ -1,7 +1,6 @@
 package com.example.nabu.screens
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,6 +23,7 @@ import com.example.nabu.utils.playCreation
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.mewmix.nabu.ui.brutalist.BrutalButton
+import com.mewmix.nabu.ui.brutalist.PanelBox
 
 @Composable
 fun CreationsScreen() {
@@ -36,13 +36,16 @@ fun CreationsScreen() {
         creations = withContext(Dispatchers.IO) { loadCreations(context) }
     }
 
-    Column(
+    PanelBox(
+        title = "Creations",
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(16.dp)
     ) {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
             items(creations) { creation ->
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/com/example/nabu/screens/CreditsConstellationScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/CreditsConstellationScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import com.mewmix.nabu.ui.brutalist.PanelBox
 
 // Data classes representing credits hierarchy
 
@@ -114,36 +115,42 @@ fun CreditsConstellationScreen() {
 
     var expandedGroup by remember { mutableStateOf<CreditGroup?>(null) }
 
-    Box(
+    PanelBox(
+        title = "Credits",
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
-            .pointerInput(expandedGroup) {
-                if (expandedGroup != null) {
-                    detectTapGestures { expandedGroup = null }
-                }
-            },
-        contentAlignment = Alignment.Center
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(expandedGroup) {
+                    if (expandedGroup != null) {
+                        detectTapGestures { expandedGroup = null }
+                    }
+                },
+            contentAlignment = Alignment.Center
         ) {
-            StarCluster(
-                group = legacyCredits,
-                expanded = expandedGroup == legacyCredits,
-                onToggle = {
-                    expandedGroup = if (expandedGroup == legacyCredits) null else legacyCredits
-                }
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            StarCluster(
-                group = ourCredits,
-                expanded = expandedGroup == ourCredits,
-                onToggle = {
-                    expandedGroup = if (expandedGroup == ourCredits) null else ourCredits
-                }
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                StarCluster(
+                    group = legacyCredits,
+                    expanded = expandedGroup == legacyCredits,
+                    onToggle = {
+                        expandedGroup = if (expandedGroup == legacyCredits) null else legacyCredits
+                    }
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                StarCluster(
+                    group = ourCredits,
+                    expanded = expandedGroup == ourCredits,
+                    onToggle = {
+                        expandedGroup = if (expandedGroup == ourCredits) null else ourCredits
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/nabu/screens/DebugLogScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/DebugLogScreen.kt
@@ -10,16 +10,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.nabu.utils.DebugLogger
+import com.mewmix.nabu.ui.brutalist.PanelBox
 
 @Composable
 fun DebugLogScreen() {
     val logs = DebugLogger.getLogs().joinToString("\n")
-    Column(
+    PanelBox(
+        title = "Debug Log",
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {
-        Text(text = logs)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(text = logs)
+        }
     }
 }
+

--- a/app/src/main/java/com/example/nabu/screens/ModelsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ModelsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -48,6 +47,7 @@ import com.example.nabu.utils.DebugLogger
 import java.io.File
 import kotlinx.coroutines.launch
 import com.mewmix.nabu.ui.brutalist.BrutalButton
+import com.mewmix.nabu.ui.brutalist.PanelBox
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -143,66 +143,71 @@ fun ModelsScreen(userPreferencesRepository: UserPreferencesRepository) {
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        LazyColumn(
+        PanelBox(
+            title = "Models",
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .padding(16.dp)
         ) {
-            item {
-                BrutalButton(onClick = { importLauncher.launch(arrayOf("*/*")) }) {
-                    Text("Import Local Model")
-                }
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-            items(models) { model ->
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Text(text = model.name, style = MaterialTheme.typography.titleMedium)
-                    Text(text = model.description, style = MaterialTheme.typography.bodyMedium)
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                item {
+                    BrutalButton(onClick = { importLauncher.launch(arrayOf("*/*")) }) {
+                        Text("Import Local Model")
+                    }
                     Spacer(modifier = Modifier.height(8.dp))
-                    val progress = progressMap[model.id]
-                    if (progress != null) {
-                        LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
-                    } else {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            if (model.isDownloaded) {
-                                Icon(
-                                    imageVector = Icons.Filled.CheckCircle,
-                                    contentDescription = "Downloaded",
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                                IconButton(onClick = {
-                                    DebugLogger.log("ModelsScreen: Deleting ${model.name}")
-                                    modelManager.deleteModel(model)
-                                }) {
-                                    Icon(Icons.Filled.Delete, contentDescription = "Delete model")
-                                }
-                            } else {
-                                IconButton(onClick = {
-                                    if (model.gated) {
-                                        selectedModel = model
-                                        showDialog = true
-                                        DebugLogger.log("ModelsScreen: Prompting token for ${model.name}")
-                                    } else {
-                                        DebugLogger.log("ModelsScreen: Downloading ${model.name}")
-                                        modelDownloader.downloadModel(model)
-                                    }
-                                }) {
+                }
+                items(models) { model ->
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Text(text = model.name, style = MaterialTheme.typography.titleMedium)
+                        Text(text = model.description, style = MaterialTheme.typography.bodyMedium)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        val progress = progressMap[model.id]
+                        if (progress != null) {
+                            LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+                        } else {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                if (model.isDownloaded) {
                                     Icon(
-                                        Icons.Filled.CloudDownload,
-                                        contentDescription = if (model.hasPartial) "Resume download" else "Download model"
+                                        imageVector = Icons.Filled.CheckCircle,
+                                        contentDescription = "Downloaded",
+                                        tint = MaterialTheme.colorScheme.primary
                                     )
-                                }
-                                if (model.hasPartial) {
-                                    IconButton(onClick = {
-                                        DebugLogger.log("ModelsScreen: Deleting partial ${model.name}")
+                                    BrutalButton(onClick = {
+                                        DebugLogger.log("ModelsScreen: Deleting ${model.name}")
                                         modelManager.deleteModel(model)
                                     }) {
-                                        Icon(Icons.Filled.Delete, contentDescription = "Delete partial model")
+                                        Icon(Icons.Filled.Delete, contentDescription = "Delete model")
+                                    }
+                                } else {
+                                    BrutalButton(onClick = {
+                                        if (model.gated) {
+                                            selectedModel = model
+                                            showDialog = true
+                                            DebugLogger.log("ModelsScreen: Prompting token for ${model.name}")
+                                        } else {
+                                            DebugLogger.log("ModelsScreen: Downloading ${model.name}")
+                                            modelDownloader.downloadModel(model)
+                                        }
+                                    }) {
+                                        Icon(
+                                            Icons.Filled.CloudDownload,
+                                            contentDescription = if (model.hasPartial) "Resume download" else "Download model",
+                                        )
+                                    }
+                                    if (model.hasPartial) {
+                                        BrutalButton(onClick = {
+                                            DebugLogger.log("ModelsScreen: Deleting partial ${model.name}")
+                                            modelManager.deleteModel(model)
+                                        }) {
+                                            Icon(Icons.Filled.Delete, contentDescription = "Delete partial model")
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/example/nabu/screens/MoreScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MoreScreen.kt
@@ -12,46 +12,49 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.nabu.utils.SettingsManager
 import com.mewmix.nabu.ui.brutalist.BrutalButton
+import com.mewmix.nabu.ui.brutalist.PanelBox
 
 @Composable
 fun MoreScreen(onNavigate: (String) -> Unit) {
     val context = LocalContext.current
-    Column(
+    PanelBox(
+        title = "More",
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            .padding(16.dp)
     ) {
-        BrutalButton(
-            onClick = { onNavigate("Creations") },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Creations")
-        }
-        BrutalButton(
-            onClick = { onNavigate("Settings") },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Settings")
-        }
-        BrutalButton(
-            onClick = { onNavigate("Models") },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Models")
-        }
-        BrutalButton(
-            onClick = { onNavigate("Credits") },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Credits")
-        }
-        if (SettingsManager.isDebug(context)) {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             BrutalButton(
-                onClick = { onNavigate("DebugLog") },
+                onClick = { onNavigate("Creations") },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Debug Log")
+                Text("Creations")
+            }
+            BrutalButton(
+                onClick = { onNavigate("Settings") },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Settings")
+            }
+            BrutalButton(
+                onClick = { onNavigate("Models") },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Models")
+            }
+            BrutalButton(
+                onClick = { onNavigate("Credits") },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Credits")
+            }
+            if (SettingsManager.isDebug(context)) {
+                BrutalButton(
+                    onClick = { onNavigate("DebugLog") },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Debug Log")
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/nabu/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/SettingsScreen.kt
@@ -1,7 +1,7 @@
 package com.example.nabu.screens
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -9,7 +9,6 @@ import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -18,7 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -27,6 +25,8 @@ import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.OnnxRuntimeManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import com.mewmix.nabu.ui.brutalist.PanelBox
+import com.mewmix.nabu.ui.brutalist.SwitchToggle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -43,54 +43,57 @@ fun SettingsScreen() {
         }
     }
 
-    Column(modifier = Modifier.padding(16.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Switch(
+    PanelBox(
+        title = "Settings",
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            SwitchToggle(
                 checked = debug,
-                onCheckedChange = {
+                onToggle = {
                     debug = it
                     SettingsManager.setDebug(context, it)
-                }
+                },
+                label = "Debug Mode"
             )
-            Text(text = "Debug Mode", modifier = Modifier.padding(start = 8.dp))
-        }
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Switch(
+            SwitchToggle(
                 checked = benchmark,
-                onCheckedChange = {
+                onToggle = {
                     benchmark = it
                     SettingsManager.setBenchmark(context, it)
-                }
+                },
+                label = "Benchmark Mode"
             )
-            Text(text = "Benchmark Mode", modifier = Modifier.padding(start = 8.dp))
-        }
 
-        ExposedDropdownMenuBox(
-            expanded = expanded,
-            onExpandedChange = { expanded = it }
-        ) {
-            TextField(
-                value = engine.name,
-                onValueChange = {},
-                readOnly = true,
-                label = { Text("TTS Engine") },
-                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                modifier = Modifier.menuAnchor().fillMaxWidth()
-            )
-            DropdownMenu(
+            ExposedDropdownMenuBox(
                 expanded = expanded,
-                onDismissRequest = { expanded = false }
+                onExpandedChange = { expanded = it }
             ) {
-                TtsEngine.values().forEach { option ->
-                    DropdownMenuItem(
-                        text = { Text(option.name) },
-                        onClick = {
-                            engine = option
-                            SettingsManager.setTtsEngine(context, option)
-                            expanded = false
-                        }
-                    )
+                TextField(
+                    value = engine.name,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("TTS Engine") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier.menuAnchor().fillMaxWidth()
+                )
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    TtsEngine.values().forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option.name) },
+                            onClick = {
+                                engine = option
+                                SettingsManager.setTtsEngine(context, option)
+                                expanded = false
+                            }
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Wrap More screen and linked pages in `PanelBox` containers
- Use Brutalist components like `BrutalButton` and `SwitchToggle`
- Replace model action buttons with brutalist equivalents

## Testing
- `./gradlew build` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68a24488f5c083319981e8b5cf7aba39