### PR TITLE
Improve slider visibility on Basic and Mixer screens

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.TextField
 import com.mewmix.nabu.ui.brutalist.PanelBox
 import com.mewmix.nabu.ui.brutalist.BrutalButton
 import com.mewmix.nabu.ui.brutalist.BrutalSlider
+import com.mewmix.nabu.ui.brutalist.PanelRow
 import com.mewmix.nabu.ui.brutalist.Brutal
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -544,16 +545,18 @@ fun BasicScreen(
             }
         }
 
-        Text("Speed: ${"%.2f".format(speed)}", color = Brutal.textBright)
-        BrutalSlider(
-            value = speed,
-            onValueChange = {
-                speed = it
-                SettingsManager.setSpeed(context, it)
-            },
-            range = 0.5f..2.0f,
-            modifier = Modifier.fillMaxWidth()
-        )
+        PanelRow(name = "Speed") {
+            BrutalSlider(
+                value = speed,
+                onValueChange = {
+                    speed = it
+                    SettingsManager.setSpeed(context, it)
+                },
+                range = 0.5f..2.0f,
+                modifier = Modifier.weight(1f)
+            )
+            Text("%.2f".format(speed))
+        }
 
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -124,16 +124,18 @@ fun MixerScreen(
             modifier = Modifier.fillMaxWidth()
             )
 
-        Text("Speed: ${"%.2f".format(speed)}", color = Brutal.textBright)
-        BrutalSlider(
-            value = speed,
-            onValueChange = {
-                speed = it
-                SettingsManager.setSpeed(context, it)
-            },
-            range = 0.5f..2.0f,
-            modifier = Modifier.fillMaxWidth()
-        )
+        PanelRow(name = "Speed") {
+            BrutalSlider(
+                value = speed,
+                onValueChange = {
+                    speed = it
+                    SettingsManager.setSpeed(context, it)
+                },
+                range = 0.5f..2.0f,
+                modifier = Modifier.weight(1f)
+            )
+            Text("%.2f".format(speed))
+        }
 
         StyleSelector(
             styleNames = styleLoader.names,


### PR DESCRIPTION
## Summary
- wrap Basic screen's speed slider in PanelRow for better contrast
- wrap Mixer screen's speed slider in PanelRow to match other screens

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68a258e9e8188331a0ecd12b56b75a8b