### PR TITLE
Simplify settings toggles

### DIFF
--- a/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
+++ b/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
@@ -246,18 +246,17 @@ fun SwitchToggle(
     modifier: Modifier = Modifier,
     ledColor: Color = Brutal.green
 ) {
+    val interaction = remember { MutableInteractionSource() }
     Row(
         modifier = modifier
             .background(Brutal.panelHl, RoundedCornerShape(6.dp))
             .border(1.dp, Brutal.panelStroke, RoundedCornerShape(6.dp))
             .padding(horizontal = 10.dp, vertical = 8.dp)
-            .pointerInput(Unit) {
-                detectDragGestures(
-                    onDragStart = { onToggle(!checked) },
-                    onDragEnd = { /* snap already handled */ },
-                    onDragCancel = {}
-                ) { _, _ -> /* tap/drag same behavior for simplicity */ }
-            },
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                role = Role.Switch
+            ) { onToggle(!checked) },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Led(on = checked, colorOn = ledColor)


### PR DESCRIPTION
## Summary
- Make SwitchToggle respond to simple taps instead of drag gestures for easier debugging and benchmarking toggle

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a259076a748331a19bab905c461643