### PR TITLE
feat: add kokoro raw text toggle

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -252,10 +252,15 @@ private fun generateAudio(
                     )
                 }
             } else {
-                val phonemes = phonemeConverter.phonemize(text)
-                DebugLogger.log("Phonemes: $phonemes")
+                val phonemes = if (useRaw) {
+                    phonemeConverter.phonemize(text)
+                } else {
+                    text
+                }
+                val logLabel = if (useRaw) "Phonemes" else "IPA"
+                DebugLogger.log("$logLabel: $phonemes")
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(context, "Phonemes: $phonemes", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, "$logLabel: $phonemes", Toast.LENGTH_LONG).show()
                 }
                 PerfHud.record("ONNX synth") {
                     createAudio(
@@ -431,13 +436,14 @@ fun BasicScreen(
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var isProcessing by remember { mutableStateOf(false) }
     var shouldSaveFile by remember { mutableStateOf(false) }
-    var useRawText by remember { mutableStateOf(false) }
+    var useRawText by remember { mutableStateOf(SettingsManager.isRawTextInput(context)) }
 
     LaunchedEffect(engine) {
         withContext(Dispatchers.IO) {
             OnnxRuntimeManager.initialize(context.applicationContext)
         }
         SettingsManager.setStyle(context, style)
+        useRawText = SettingsManager.isRawTextInput(context)
     }
 
     var expanded by remember { mutableStateOf(false) }
@@ -534,14 +540,20 @@ fun BasicScreen(
             }
         }
 
-        if (engine == TtsEngine.KITTEN) {
+        if (engine == TtsEngine.KITTEN || engine == TtsEngine.KOKORO) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Raw text input")
                 Spacer(modifier = Modifier.width(8.dp))
-                Switch(checked = useRawText, onCheckedChange = { useRawText = it })
+                Switch(
+                    checked = useRawText,
+                    onCheckedChange = {
+                        useRawText = it
+                        SettingsManager.setRawTextInput(context, it)
+                    }
+                )
             }
         }
 

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -366,10 +366,15 @@ fun BookScreen(
                                 )
                                 val audioData = mutableListOf<Float>()
                                 val engine = SettingsManager.getTtsEngine(context)
+                                val useRaw = SettingsManager.isRawTextInput(context)
                                 val sampleRate = if (engine == TtsEngine.KITTEN) 24000 else 22050
                                 for (line in lines) {
                                     val (audio, _) = if (engine == TtsEngine.KITTEN) {
-                                        val (_, tokens) = KittenPhonemizer.phonemize(line)
+                                        val (_, tokens) = if (useRaw) {
+                                            KittenPhonemizer.encodeText(line)
+                                        } else {
+                                            KittenPhonemizer.phonemize(line)
+                                        }
                                         createKittenAudioFromStyleVector(
                                             tokens = tokens,
                                             voice = mixedVector,
@@ -377,7 +382,11 @@ fun BookScreen(
                                             session = session
                                         )
                                     } else {
-                                        val phonemes = phonemeConverter.phonemize(line)
+                                        val phonemes = if (useRaw) {
+                                            phonemeConverter.phonemize(line)
+                                        } else {
+                                            line
+                                        }
                                         createAudioFromStyleVector(
                                             phonemes = phonemes,
                                             voice = mixedVector,
@@ -416,10 +425,16 @@ fun BookScreen(
                                     )
                                     val audioData = mutableListOf<Float>()
                                     val engine = SettingsManager.getTtsEngine(context)
+                                    val useRaw = SettingsManager.isRawTextInput(context)
                                     val sampleRate = if (engine == TtsEngine.KITTEN) 24000 else 22050
                                     for (i in selectedLines.sorted()) {
+                                        val line = lines[i]
                                         val (audio, _) = if (engine == TtsEngine.KITTEN) {
-                                            val (_, tokens) = KittenPhonemizer.phonemize(lines[i])
+                                            val (_, tokens) = if (useRaw) {
+                                                KittenPhonemizer.encodeText(line)
+                                            } else {
+                                                KittenPhonemizer.phonemize(line)
+                                            }
                                             createKittenAudioFromStyleVector(
                                                 tokens = tokens,
                                                 voice = mixedVector,
@@ -427,7 +442,11 @@ fun BookScreen(
                                                 session = session
                                             )
                                         } else {
-                                            val phonemes = phonemeConverter.phonemize(lines[i])
+                                            val phonemes = if (useRaw) {
+                                                phonemeConverter.phonemize(line)
+                                            } else {
+                                                line
+                                            }
                                             createAudioFromStyleVector(
                                                 phonemes = phonemes,
                                                 voice = mixedVector,

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -256,8 +256,13 @@ private fun generateAudio(
     scope.launch(Dispatchers.IO) {
         try {
             val engine = SettingsManager.getTtsEngine(context)
+            val useRaw = SettingsManager.isRawTextInput(context)
             val (audio, sampleRate) = if (engine == TtsEngine.KITTEN) {
-                val (_, tokens) = KittenPhonemizer.phonemize(text)
+                val (_, tokens) = if (useRaw) {
+                    KittenPhonemizer.encodeText(text)
+                } else {
+                    KittenPhonemizer.phonemize(text)
+                }
                 createKittenAudioFromStyleVector(
                     tokens = tokens,
                     voice = style,
@@ -265,7 +270,11 @@ private fun generateAudio(
                     session = session
                 )
             } else {
-                val phonemes = phonemeConverter.phonemize(text)
+                val phonemes = if (useRaw) {
+                    phonemeConverter.phonemize(text)
+                } else {
+                    text
+                }
                 createAudioFromStyleVector(
                     phonemes = phonemes,
                     voice = style,

--- a/app/src/main/java/com/example/nabu/utils/AudioPreGenerator.kt
+++ b/app/src/main/java/com/example/nabu/utils/AudioPreGenerator.kt
@@ -29,8 +29,13 @@ suspend fun preGenerateBook(
         if (DatabaseManager.getAudioLine(context, project.uri, index) != null) continue
         DebugLogger.log("Generating line $index for ${project.uri}")
         val engine = SettingsManager.getTtsEngine(context)
+        val useRaw = SettingsManager.isRawTextInput(context)
         val (audio, sampleRate) = if (engine == TtsEngine.KITTEN) {
-            val (_, tokens) = KittenPhonemizer.phonemize(line)
+            val (_, tokens) = if (useRaw) {
+                KittenPhonemizer.encodeText(line)
+            } else {
+                KittenPhonemizer.phonemize(line)
+            }
             createKittenAudioFromStyleVector(
                 tokens = tokens,
                 voice = mixed,
@@ -38,7 +43,11 @@ suspend fun preGenerateBook(
                 session = session,
             )
         } else {
-            val phonemes = phonemeConverter.phonemize(line)
+            val phonemes = if (useRaw) {
+                phonemeConverter.phonemize(line)
+            } else {
+                line
+            }
             createAudioFromStyleVector(
                 phonemes = phonemes,
                 voice = mixed,

--- a/app/src/main/java/com/example/nabu/utils/BookPlayer.kt
+++ b/app/src/main/java/com/example/nabu/utils/BookPlayer.kt
@@ -56,8 +56,13 @@ fun playBook(
                     }
                     val line = lines[index]
                     val engine = SettingsManager.getTtsEngine(context)
+                    val useRaw = SettingsManager.isRawTextInput(context)
                     if (engine == TtsEngine.KITTEN) {
-                        val (_, tokens) = KittenPhonemizer.phonemize(line)
+                        val (_, tokens) = if (useRaw) {
+                            KittenPhonemizer.encodeText(line)
+                        } else {
+                            KittenPhonemizer.phonemize(line)
+                        }
                         val (audio, _) = createKittenAudioFromStyleVector(
                             tokens = tokens,
                             voice = mixedVector,
@@ -66,7 +71,11 @@ fun playBook(
                         )
                         audioBuffer.send(Pair(audio, index))
                     } else {
-                        val phonemes = phonemeConverter.phonemize(line)
+                        val phonemes = if (useRaw) {
+                            phonemeConverter.phonemize(line)
+                        } else {
+                            line
+                        }
                         createAudioFlowFromStyleVector(
                             phonemes = phonemes,
                             voice = mixedVector,

--- a/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
@@ -39,4 +39,11 @@ object SettingsManager {
         DatabaseManager.getSetting(context, "tts_engine")?.let {
             runCatching { TtsEngine.valueOf(it) }.getOrNull()
         } ?: default
+
+    fun setRawTextInput(context: Context, enabled: Boolean) {
+        DatabaseManager.setSetting(context, "raw_text_input", if (enabled) "1" else "0")
+    }
+
+    fun isRawTextInput(context: Context): Boolean =
+        (DatabaseManager.getSetting(context, "raw_text_input") ?: "1") == "1"
 }

--- a/app/src/main/java/com/example/nabu/viewmodel/ChatTtsViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/ChatTtsViewModel.kt
@@ -195,9 +195,14 @@ class ChatTtsViewModel(
                         _interpolationMode.value
                     )
                     val engine = SettingsManager.getTtsEngine(context)
+                    val useRaw = SettingsManager.isRawTextInput(context)
                     val ttsStart = SystemClock.elapsedRealtime()
                     val (data, sampleRate) = if (engine == TtsEngine.KITTEN) {
-                        val (_, tokens) = KittenPhonemizer.phonemize(text)
+                        val (_, tokens) = if (useRaw) {
+                            KittenPhonemizer.encodeText(text)
+                        } else {
+                            KittenPhonemizer.phonemize(text)
+                        }
                         createKittenAudioFromStyleVector(
                             tokens = tokens,
                             voice = mixedVector,
@@ -205,7 +210,11 @@ class ChatTtsViewModel(
                             session = ortSession
                         )
                     } else {
-                        val phonemes = phonemeConverter.phonemize(text)
+                        val phonemes = if (useRaw) {
+                            phonemeConverter.phonemize(text)
+                        } else {
+                            text
+                        }
                         createAudioFromStyleVector(
                             phonemes = phonemes,
                             voice = mixedVector,


### PR DESCRIPTION
## Summary
- add persistent raw text input toggle for Kokoro and Kitten
- respect raw text setting across basic, mixer, book, chat screens and utilities

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a265e3d9548331ac62ebff0a9017e1