### PR TITLE
Implement sentence-aware PlayableUnit text processing

### DIFF
--- a/app/src/main/java/com/example/nabu/data/PlayableUnit.kt
+++ b/app/src/main/java/com/example/nabu/data/PlayableUnit.kt
@@ -1,0 +1,7 @@
+package com.example.nabu.data
+
+data class PlayableUnit(
+    val text: String,
+    val paragraphIndex: Int,
+    val unitIndex: Int,
+)

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -53,8 +53,9 @@ fun BookScreen(
         }
     }
 
-    val lines by bookViewModel.lines.collectAsState()
-    val currentLine by bookViewModel.currentLine.collectAsState()
+    val playableUnits by bookViewModel.playableUnits.collectAsState()
+    val currentUnitIndex by bookViewModel.currentUnitIndex.collectAsState()
+    val lines = playableUnits.map { it.text }
     val playerState by bookViewModel.playerState.collectAsState()
 
     val bookUri by bookViewModel.bookUri.collectAsState()
@@ -111,19 +112,19 @@ fun BookScreen(
                  projectName = project.name
                  usePregenerated = project.usePregenerated
                 DebugLogger.log("Loaded project: $project")
-                bookViewModel.setCurrentLine(project.bookmark?.line ?: 0)
+                bookViewModel.setCurrentUnitIndex(project.bookmark?.line ?: 0)
             } else {
                 bookmark = BookmarkManager.load(context, uri.toString())
                 DebugLogger.log("Loaded bookmark: $bookmark")
-                bookmark?.let { bookViewModel.setCurrentLine(it.line) } ?: bookViewModel.setCurrentLine(0)
+                bookmark?.let { bookViewModel.setCurrentUnitIndex(it.line) } ?: bookViewModel.setCurrentUnitIndex(0)
             }
             projects = ProjectManager.list(context)
         }
     }
 
-    LaunchedEffect(currentLine) {
-        if (currentLine >= 0) {
-            listState.animateScrollToItem(currentLine)
+    LaunchedEffect(currentUnitIndex) {
+        if (currentUnitIndex >= 0) {
+            listState.animateScrollToItem(currentUnitIndex)
         }
     }
 
@@ -267,13 +268,13 @@ fun BookScreen(
                     horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_medium))
                 ) {
                     Text("Resume at line ${bookmark!!.line + 1}")
-                    BrutalButton(onClick = { bookViewModel.setCurrentLine(bookmark!!.line) }) {
+                    BrutalButton(onClick = { bookViewModel.setCurrentUnitIndex(bookmark!!.line) }) {
                         Text("Go")
                     }
                     BrutalButton(onClick = {
                         bookUri?.let { BookmarkManager.clear(context, it.toString()) }
                         bookmark = null
-                        bookViewModel.setCurrentLine(-1)
+                        bookViewModel.setCurrentUnitIndex(-1)
                     }) {
                         Text("Clear")
                     }
@@ -294,8 +295,8 @@ fun BookScreen(
                         if (playerState == PlayerState.PLAYING) {
                             bookViewModel.audioPlayer.pause()
                             bookUri?.let {
-                                DebugLogger.log("Saving bookmark at line $currentLine")
-                                BookmarkManager.save(context, it.toString(), currentLine)
+                                DebugLogger.log("Saving bookmark at line $currentUnitIndex")
+                                BookmarkManager.save(context, it.toString(), currentUnitIndex)
                                 val project = Project(
                                     uri = it.toString(),
                                     name = projectName,
@@ -303,11 +304,11 @@ fun BookScreen(
                                     weights = weights,
                                     mode = interpolationMode,
                                     speed = speed,
-                                    bookmark = Bookmark(currentLine),
+                                    bookmark = Bookmark(currentUnitIndex),
                                     usePregenerated = usePregenerated
                                 )
                                 ProjectManager.save(context, project)
-                                bookmark = Bookmark(currentLine)
+                                bookmark = Bookmark(currentUnitIndex)
                             }
                         } else {
                             if (playerState == PlayerState.PAUSED) {
@@ -321,8 +322,8 @@ fun BookScreen(
                                 weights = weights,
                                 mode = interpolationMode,
                                 speed = speed,
-                                lines = lines,
-                                startLine = currentLine.coerceAtLeast(0),
+                                units = playableUnits,
+                                startUnit = currentUnitIndex.coerceAtLeast(0),
                                 bookUri = bookUri,
                                 context = context,
                                 engine = SettingsManager.getTtsEngine(context),
@@ -515,7 +516,7 @@ fun BookScreen(
                             if (selectedLines.contains(index)) {
                                 selectedLines.remove(index)
                             } else {
-                                bookViewModel.setCurrentLine(index)
+                                bookViewModel.setCurrentUnitIndex(index)
                                 bookViewModel.startPlayback(
                                     session = session,
                                     phonemeConverter = phonemeConverter,
@@ -524,8 +525,8 @@ fun BookScreen(
                                     weights = weights,
                                     mode = interpolationMode,
                                     speed = speed,
-                                    lines = lines,
-                                    startLine = index,
+                                    units = playableUnits,
+                                    startUnit = index,
                                     bookUri = bookUri,
                                     context = context,
                                     engine = SettingsManager.getTtsEngine(context),
@@ -548,7 +549,7 @@ fun BookScreen(
                     .background(
                         when {
                             selectedLines.contains(index) -> MaterialTheme.colorScheme.secondaryContainer
-                            index == currentLine -> MaterialTheme.colorScheme.primaryContainer
+                            index == currentUnitIndex -> MaterialTheme.colorScheme.primaryContainer
                             else -> Color.Transparent
                         }
                     )

--- a/app/src/main/java/com/example/nabu/utils/DocumentReader.kt
+++ b/app/src/main/java/com/example/nabu/utils/DocumentReader.kt
@@ -2,39 +2,58 @@ package com.example.nabu.utils
 
 import android.content.Context
 import android.net.Uri
+import com.example.nabu.data.PlayableUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
 object DocumentReader {
-    data class Result(val chunks: Flow<String>, val title: String)
+    private const val SAFE_CHAR_LIMIT = 280
 
-    fun asFlow(
-        ctx: Context,
-        uri: Uri,
-        chunkSize: Int = 1600,
-        byLine: Boolean = false,
-        lineLength: Int = 120
-    ): Result {
-        val (seq, meta) = TextExtractor.extract(ctx, uri, if (byLine) Int.MAX_VALUE else chunkSize)
-        val fl = flow {
-            for (block in seq) {
-                if (byLine) {
-                    // Split incoming text on punctuation or whitespace to create stable
-                    // line-based chunks suitable for bookmarking, while preserving
-                    // document loading behaviour across formats like EPUB.
-                    block.split(Regex("(?<=[.!?])\\s+|\\n+"))
-                        .asSequence()
-                        .flatMap { it.chunked(lineLength).asSequence() }
-                        .map { it.trim() }
-                        .filter { it.isNotEmpty() }
-                        .forEach { emit(it) }
-                } else {
-                    emit(block)
+    fun asPlayableUnits(ctx: Context, uri: Uri): Flow<PlayableUnit> {
+        val (textSequence, _) = TextExtractor.extract(ctx, uri, chunkSize = Int.MAX_VALUE)
+        return flow {
+            textSequence.forEachIndexed { paragraphIndex, paragraphText ->
+                val sentences = paragraphText
+                    .split(Regex("(?<=[.!?])\\s*"))
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() }
+
+                if (sentences.isEmpty()) return@forEachIndexed
+
+                var unitIndexInParagraph = 0
+                val sentenceBuffer = StringBuilder()
+
+                sentences.forEach { sentence ->
+                    if (sentenceBuffer.isNotEmpty() && sentenceBuffer.length + sentence.length > SAFE_CHAR_LIMIT) {
+                        emit(
+                            PlayableUnit(
+                                text = sentenceBuffer.toString(),
+                                paragraphIndex = paragraphIndex,
+                                unitIndex = unitIndexInParagraph,
+                            ),
+                        )
+                        sentenceBuffer.clear()
+                        unitIndexInParagraph++
+                    }
+
+                    if (sentenceBuffer.isNotEmpty()) {
+                        sentenceBuffer.append(" ")
+                    }
+                    sentenceBuffer.append(sentence)
+                }
+
+                if (sentenceBuffer.isNotEmpty()) {
+                    emit(
+                        PlayableUnit(
+                            text = sentenceBuffer.toString(),
+                            paragraphIndex = paragraphIndex,
+                            unitIndex = unitIndexInParagraph,
+                        ),
+                    )
                 }
             }
         }.flowOn(Dispatchers.IO)
-        return Result(chunks = fl, title = meta.displayName)
     }
 }

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -6,17 +6,18 @@ import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import ai.onnxruntime.OrtSession
+import com.example.nabu.data.PlayableUnit
 import com.example.nabu.utils.AudioPlayer
 import com.example.nabu.utils.AudioPlayerManager
-import com.example.nabu.utils.InterpolationMode
 import com.example.nabu.utils.ChunkFeeder
+import com.example.nabu.utils.DocumentReader
+import com.example.nabu.utils.InterpolationMode
 import com.example.nabu.utils.KittenAudioPlayer
 import com.example.nabu.utils.KokoroAudioPlayer
 import com.example.nabu.utils.PhonemeConverter
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PlaybackNotification
 import com.example.nabu.utils.StyleLoader
-import com.example.nabu.utils.DocumentReader
 import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.playBook
 import kotlinx.coroutines.Dispatchers
@@ -24,6 +25,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -31,11 +33,11 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     private val _bookUri = MutableStateFlow<Uri?>(null)
     val bookUri = _bookUri.asStateFlow()
 
-    private val _lines = MutableStateFlow<List<String>>(emptyList())
-    val lines = _lines.asStateFlow()
+    private val _playableUnits = MutableStateFlow<List<PlayableUnit>>(emptyList())
+    val playableUnits = _playableUnits.asStateFlow()
 
-    private val _currentLine = MutableStateFlow(-1)
-    val currentLine = _currentLine.asStateFlow()
+    private val _currentUnitIndex = MutableStateFlow(-1)
+    val currentUnitIndex = _currentUnitIndex.asStateFlow()
 
     private val _playerState = MutableStateFlow(PlayerState.IDLE)
     val playerState = _playerState.asStateFlow()
@@ -64,18 +66,17 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
         viewModelScope.launch(Dispatchers.IO) {
-            val lines = DocumentReader
-                .asFlow(context, uri, byLine = true, lineLength = 120)
-                .chunks
+            val units = DocumentReader
+                .asPlayableUnits(context, uri)
                 .toList()
             withContext(Dispatchers.Main) {
-                _lines.value = lines
+                _playableUnits.value = units
             }
         }
     }
 
-    fun setCurrentLine(line: Int) {
-        _currentLine.value = line
+    fun setCurrentUnitIndex(index: Int) {
+        _currentUnitIndex.value = index
     }
 
     fun startPlayback(
@@ -86,8 +87,8 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         weights: Map<String, Float>,
         mode: InterpolationMode,
         speed: Float,
-        lines: List<String>,
-        startLine: Int,
+        units: List<PlayableUnit>,
+        startUnit: Int,
         bookUri: Uri?,
         context: Context,
         engine: TtsEngine,
@@ -108,12 +109,12 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
             weights = weights,
             mode = mode,
             speed = speed,
-            lines = lines,
-            startLine = startLine,
+            lines = units.map { it.text },
+            startLine = startUnit,
             bookUri = bookUri,
             audioPlayer = audioPlayer,
             context = context,
-            onLineChanged = { setCurrentLine(it) },
+            onLineChanged = { setCurrentUnitIndex(it) },
             onFinished = onFinished,
             usePregenerated = usePregenerated,
         )
@@ -128,8 +129,8 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     fun openDocument(uri: Uri) {
-        val result = DocumentReader.asFlow(app, uri, byLine = true, lineLength = 120)
-        ChunkFeeder.start(viewModelScope, result.chunks)
+        val flow = DocumentReader.asPlayableUnits(app, uri)
+        ChunkFeeder.start(viewModelScope, flow.map { it.text })
     }
 
     fun stopReading() {


### PR DESCRIPTION
## Summary
- Introduce PlayableUnit model for tracking paragraph and unit indices
- Replace DocumentReader chunking with sentence-aware PlayableUnits
- Update BookViewModel and BookScreen to operate on PlayableUnits for accurate playback

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2695fdb20833195c0f3870becb4bd