### PR TITLE
Improve contrast for highlighted playback text

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -549,13 +549,18 @@ fun BookScreen(
                     .background(
                         when {
                             selectedLines.contains(index) -> MaterialTheme.colorScheme.secondaryContainer
-                            index == currentUnitIndex -> MaterialTheme.colorScheme.primaryContainer
+                            index == currentUnitIndex -> Brutal.panelStroke
                             else -> Color.Transparent
                         }
                     )
                     .padding(dimensionResource(id = R.dimen.padding_small)),
                 textAlign = TextAlign.Justify,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                color = when {
+                    selectedLines.contains(index) -> MaterialTheme.colorScheme.onSecondaryContainer
+                    index == currentUnitIndex -> Brutal.textBright
+                    else -> MaterialTheme.colorScheme.onBackground
+                }
             )
         }
 


### PR DESCRIPTION
## Summary
- Use gunmetal panel background for current playback line in BookScreen
- Adjust highlighted text color for readability and matched theme

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e2cf01483319e05be1c15ac2a05