### PR TITLE
Add controllable playback notification

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -13,8 +13,6 @@ import com.example.nabu.screens.CreditsConstellationScreen
 import com.example.kokoro.galleryport.PerfHud
 import ai.onnxruntime.OrtSession
 import android.app.Application
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -72,7 +70,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
-import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.nabu.data.UserPreferencesRepository
@@ -98,8 +95,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 const val EXTRA_START_SCREEN = "start_screen"
-private const val PLAYBACK_CHANNEL_ID = "playback_channel"
-private const val PLAYBACK_NOTIFICATION_ID = 1
 
 class MyApplication : Application() {
     override fun onCreate() {
@@ -108,35 +103,6 @@ class MyApplication : Application() {
     }
 }
 
-private fun showPlaybackNotification(context: Context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-        ContextCompat.checkSelfPermission(
-            context,
-            android.Manifest.permission.POST_NOTIFICATIONS
-        ) != PackageManager.PERMISSION_GRANTED
-    ) {
-        return
-    }
-
-    val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        val channel = NotificationChannel(
-            PLAYBACK_CHANNEL_ID,
-            "Playback",
-            NotificationManager.IMPORTANCE_LOW
-        )
-        manager.createNotificationChannel(channel)
-    }
-
-    val notification = NotificationCompat.Builder(context, PLAYBACK_CHANNEL_ID)
-        .setSmallIcon(android.R.drawable.ic_media_play)
-        .setContentTitle("Playback")
-        .setContentText("Audio playback in progress")
-        .setOngoing(true)
-        .build()
-
-    manager.notify(PLAYBACK_NOTIFICATION_ID, notification)
-}
 
 class MainActivity : ComponentActivity() {
     private lateinit var phonemeConverter: PhonemeConverter
@@ -144,11 +110,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var userPreferencesRepository: UserPreferencesRepository
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        if (isGranted) {
-            showPlaybackNotification(this)
-        }
-    }
+    ) { _ -> }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -280,8 +242,6 @@ private fun generateAudio(
                 scope,
                 onComplete = onComplete
             )
-
-            showPlaybackNotification(context)
 
             if (shouldSave) {
                 saveAudio(audioData, context, style, sampleRate)

--- a/app/src/main/java/com/example/nabu/utils/PlaybackNotification.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlaybackNotification.kt
@@ -12,34 +12,37 @@ import androidx.core.app.NotificationManagerCompat
 object PlaybackNotification {
     private const val CHANNEL_ID = "book_playback_channel"
     private const val NOTIFICATION_ID = 1001
+    private var currentFile: String = ""
 
-    fun show(context: Context, playing: Boolean) {
+    fun show(context: Context, playing: Boolean, fileName: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (context.checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
                 return
             }
         }
+        currentFile = fileName
         createChannel(context)
-        val notification = buildNotification(context, playing)
+        val notification = buildNotification(context, playing, fileName)
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
     }
 
     fun update(context: Context, state: PlayerState) {
         when (state) {
-            PlayerState.PLAYING -> show(context, true)
-            PlayerState.PAUSED -> show(context, false)
+            PlayerState.PLAYING -> show(context, true, currentFile)
+            PlayerState.PAUSED -> show(context, false, currentFile)
             PlayerState.IDLE -> cancel(context)
         }
     }
 
     fun cancel(context: Context) {
         NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
+        currentFile = ""
     }
 
-    private fun buildNotification(context: Context, playing: Boolean) =
+    private fun buildNotification(context: Context, playing: Boolean, fileName: String) =
         NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle("Book Playback")
+            .setContentTitle(fileName)
             .setContentText(if (playing) "Playing" else "Paused")
             .setOngoing(playing)
             .addAction(
@@ -49,6 +52,16 @@ object PlaybackNotification {
                     context,
                     0,
                     Intent(PlaybackReceiver.ACTION_TOGGLE),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+            )
+            .addAction(
+                android.R.drawable.ic_media_stop,
+                "Stop",
+                PendingIntent.getBroadcast(
+                    context,
+                    1,
+                    Intent(PlaybackReceiver.ACTION_STOP),
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
             )

--- a/app/src/main/java/com/example/nabu/utils/PlaybackReceiver.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlaybackReceiver.kt
@@ -6,19 +6,28 @@ import android.content.Intent
 
 class PlaybackReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == ACTION_TOGGLE) {
-            val player = AudioPlayerManager.player ?: return
-            if (player.getState() == PlayerState.PLAYING) {
-                player.pause()
-                PlaybackNotification.update(context, PlayerState.PAUSED)
-            } else {
-                player.play()
-                PlaybackNotification.update(context, PlayerState.PLAYING)
+        when (intent.action) {
+            ACTION_TOGGLE -> {
+                val player = AudioPlayerManager.player ?: return
+                if (player.getState() == PlayerState.PLAYING) {
+                    player.pause()
+                    PlaybackNotification.update(context, PlayerState.PAUSED)
+                } else {
+                    player.play()
+                    PlaybackNotification.update(context, PlayerState.PLAYING)
+                }
+            }
+            ACTION_STOP -> {
+                val player = AudioPlayerManager.player ?: return
+                player.stop()
+                AudioPlayerManager.player = null
+                PlaybackNotification.update(context, PlayerState.IDLE)
             }
         }
     }
 
     companion object {
         const val ACTION_TOGGLE = "com.example.kokoro82m.PLAYBACK_TOGGLE"
+        const val ACTION_STOP = "com.example.kokoro82m.PLAYBACK_STOP"
     }
 }

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -99,7 +99,8 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         appContext = context.applicationContext
         initializeAudioPlayer(engine)
         AudioPlayerManager.player = audioPlayer
-        PlaybackNotification.show(appContext!!, true)
+        val fileName = bookUri?.lastPathSegment ?: "Playback"
+        PlaybackNotification.show(appContext!!, true, fileName)
         playJob = playBook(
             scope = viewModelScope,
             session = session,


### PR DESCRIPTION
## Summary
- link playback notifications to play/pause/stop actions
- show current file name in playback notification
- ensure notifications clear when playback stops and remove stale notification

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26eb7eeac8331a612849f123aa920