### PR TITLE
Add waveform style toggle and playback support

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -89,6 +90,9 @@ import com.example.nabu.utils.SettingsManager
 import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.DebugLogger
 import com.example.nabu.utils.OnnxRuntimeManager
+import com.example.nabu.utils.PcmTap
+import com.example.nabu.ui.components.WaveformVisualizer
+import com.example.nabu.ui.components.RadialWaveformVisualizer
 import com.google.android.material.color.DynamicColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -432,6 +436,11 @@ fun BasicScreen(
     var isProcessing by remember { mutableStateOf(false) }
     var shouldSaveFile by remember { mutableStateOf(false) }
     var useRawText by remember { mutableStateOf(false) }
+    var isPlaying by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        PcmTap.enabled = false
+    }
 
     LaunchedEffect(engine) {
         withContext(Dispatchers.IO) {
@@ -558,6 +567,23 @@ fun BasicScreen(
             Text("%.2f".format(speed))
         }
 
+        val radial = SettingsManager.isRadialWaveform(context)
+        if (radial) {
+            RadialWaveformVisualizer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                visible = isPlaying
+            )
+        } else {
+            WaveformVisualizer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                visible = isPlaying
+            )
+        }
+
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -567,8 +593,15 @@ fun BasicScreen(
                 onClick = {
                     shouldSaveFile = false
                     isProcessing = true
+                    isPlaying = true
+                    PcmTap.enabled = true
                     onGenerateAudio(text, style, speed, shouldSaveFile, useRawText) {
-                        isProcessing = false
+                        if (isProcessing) {
+                            isProcessing = false
+                        } else {
+                            isPlaying = false
+                            PcmTap.enabled = false
+                        }
                     }
                 },
                 modifier = Modifier
@@ -585,8 +618,15 @@ fun BasicScreen(
                 onClick = {
                     shouldSaveFile = true
                     isProcessing = true
+                    isPlaying = true
+                    PcmTap.enabled = true
                     onGenerateAudio(text, style, speed, shouldSaveFile, useRawText) {
-                        isProcessing = false
+                        if (isProcessing) {
+                            isProcessing = false
+                        } else {
+                            isPlaying = false
+                            PcmTap.enabled = false
+                        }
                     }
                 },
                 modifier = Modifier

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -26,6 +26,7 @@ import com.example.nabu.R
 import com.example.nabu.utils.*
 import com.example.nabu.ui.components.ProgressDialog
 import com.example.nabu.ui.components.RadialWaveformVisualizer
+import com.example.nabu.ui.components.WaveformVisualizer
 import com.example.nabu.viewmodel.BookViewModel
 import kotlinx.coroutines.launch
 import com.mewmix.nabu.ui.brutalist.PanelBox
@@ -498,12 +499,22 @@ fun BookScreen(
         }
 
         item {
-            RadialWaveformVisualizer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(150.dp),
-                visible = playerState == PlayerState.PLAYING
-            )
+            val radial = SettingsManager.isRadialWaveform(context)
+            if (radial) {
+                RadialWaveformVisualizer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(150.dp),
+                    visible = playerState == PlayerState.PLAYING
+                )
+            } else {
+                WaveformVisualizer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(150.dp),
+                    visible = playerState == PlayerState.PLAYING
+                )
+            }
         }
 
         itemsIndexed(lines) { index, line ->

--- a/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatTtsScreen.kt
@@ -45,6 +45,8 @@ import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PcmTap
 import com.example.nabu.viewmodel.ChatTtsViewModel
 import com.example.nabu.ui.components.WaveformVisualizer
+import com.example.nabu.ui.components.RadialWaveformVisualizer
+import com.example.nabu.utils.SettingsManager
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,6 +76,8 @@ fun ChatTtsScreen(
             listState.animateScrollToItem(chatMessages.size - 1)
         }
     }
+
+    val context = LocalContext.current
 
     Scaffold { paddingValues ->
         PanelBox(
@@ -140,12 +144,22 @@ fun ChatTtsScreen(
                 }
             }
 
-            WaveformVisualizer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(100.dp),
-                visible = playerState == PlayerState.PLAYING
-            )
+            val radial = SettingsManager.isRadialWaveform(context)
+            if (radial) {
+                RadialWaveformVisualizer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    visible = playerState == PlayerState.PLAYING
+                )
+            } else {
+                WaveformVisualizer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    visible = playerState == PlayerState.PLAYING
+                )
+            }
 
             // Chat Messages
             LazyColumn(

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -66,6 +66,9 @@ import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.DebugLogger
 import com.example.nabu.utils.OnnxRuntimeManager
 import com.example.nabu.utils.buildStyleFileName
+import com.example.nabu.utils.PcmTap
+import com.example.nabu.ui.components.WaveformVisualizer
+import com.example.nabu.ui.components.RadialWaveformVisualizer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -92,6 +95,8 @@ fun MixerScreen(
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var isProcessing by remember { mutableStateOf(false) }
     var shouldSaveFile by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { PcmTap.enabled = true }
 
     val defaultVoice = styleLoader.names.firstOrNull() ?: "af_sky"
     val initial = remember {
@@ -168,6 +173,23 @@ fun MixerScreen(
                 saveStyleConfig(context, selectedStyles, weights, interpolationMode)
             }
         )
+
+        val radial = SettingsManager.isRadialWaveform(context)
+        if (radial) {
+            RadialWaveformVisualizer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                visible = true
+            )
+        } else {
+            WaveformVisualizer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp),
+                visible = true
+            )
+        }
 
         Row(modifier = Modifier.fillMaxWidth()) {
             BrutalButton(

--- a/app/src/main/java/com/example/nabu/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/SettingsScreen.kt
@@ -34,6 +34,7 @@ fun SettingsScreen() {
     val context = LocalContext.current
     var debug by remember { mutableStateOf(SettingsManager.isDebug(context)) }
     var benchmark by remember { mutableStateOf(SettingsManager.isBenchmark(context)) }
+    var radial by remember { mutableStateOf(SettingsManager.isRadialWaveform(context)) }
     var engine by remember { mutableStateOf(SettingsManager.getTtsEngine(context)) }
     var expanded by remember { mutableStateOf(false) }
 
@@ -66,6 +67,15 @@ fun SettingsScreen() {
                     SettingsManager.setBenchmark(context, it)
                 },
                 label = "Benchmark Mode"
+            )
+
+            SwitchToggle(
+                checked = radial,
+                onToggle = {
+                    radial = it
+                    SettingsManager.setRadialWaveform(context, it)
+                },
+                label = "Radial Waveform"
             )
 
             ExposedDropdownMenuBox(

--- a/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
@@ -39,4 +39,11 @@ object SettingsManager {
         DatabaseManager.getSetting(context, "tts_engine")?.let {
             runCatching { TtsEngine.valueOf(it) }.getOrNull()
         } ?: default
+
+    fun setRadialWaveform(context: Context, enabled: Boolean) {
+        DatabaseManager.setSetting(context, "radial_waveform", if (enabled) "1" else "0")
+    }
+
+    fun isRadialWaveform(context: Context): Boolean =
+        (DatabaseManager.getSetting(context, "radial_waveform") ?: "0") == "1"
 }


### PR DESCRIPTION
## Summary
- add radial waveform preference and brutalist toggle
- display selected waveform on basic, mixer, book, and chat TTS screens
- feed PCM data during playback for basic screen

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68a2771c7a8c8331b3e2ecd7b9136ba2