### PR TITLE
Ensure highlighted book text remains readable

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -564,6 +564,11 @@ fun BookScreen(
                         }
                     )
                     .padding(dimensionResource(id = R.dimen.padding_small)),
+                color = when {
+                    selectedLines.contains(index) -> MaterialTheme.colorScheme.onSecondaryContainer
+                    index == currentUnitIndex -> MaterialTheme.colorScheme.onPrimaryContainer
+                    else -> MaterialTheme.colorScheme.onSurface
+                },
                 textAlign = TextAlign.Justify,
                 style = MaterialTheme.typography.bodyLarge
             )


### PR DESCRIPTION
## Summary
- Darken text color for the active or selected book line so highlighting doesn't wash out white text

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a28baeb8948331b7ee7c19c075dc38