### PR TITLE
Handle capitalized 'It' as word

### DIFF
--- a/app/src/main/java/com/example/nabu/utils/PhonemeConverter.kt
+++ b/app/src/main/java/com/example/nabu/utils/PhonemeConverter.kt
@@ -44,11 +44,11 @@ class PhonemeConverter(context: Context) {
         val cleanUpper = word.replace(Regex("[^a-zA-Z']"), "").uppercase()
         val phonemesFromDict = phonemeMap[cleanUpper]
 
-        val wasAllLowercase = word.all { it.isLowerCase() }
-        if (phonemesFromDict != null && wasAllLowercase && word.length <= 3) {
+        val isAllUppercase = word.all { it.isUpperCase() }
+        if (phonemesFromDict != null && !isAllUppercase && word.length <= 3) {
             val stressCount = phonemesFromDict.count { it == 'ˈ' || it == 'ˌ' }
             if (stressCount > 1) {
-                return fallbackTranscribe(word)
+                return fallbackTranscribe(word.lowercase())
             }
         }
 

--- a/app/src/test/java/com/example/nabu/utils/PhonemeAcronymTest.kt
+++ b/app/src/test/java/com/example/nabu/utils/PhonemeAcronymTest.kt
@@ -22,5 +22,11 @@ class PhonemeAcronymTest {
         val phonemes = converter.phonemize("it")
         assertEquals("ɪt", phonemes)
     }
+
+    @Test
+    fun `It at sentence start is not treated as initialism`() {
+        val phonemes = converter.phonemize("It")
+        assertEquals("ɪt", phonemes)
+    }
 }
 


### PR DESCRIPTION
## Summary
- avoid interpreting mixed-case short words like "It" as initialisms
- add regression test for capitalized "It"

## Testing
- `gradle test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a28b7220948331bb0892919e22dc39