### PR TITLE
feat: disable book screen when using Kitten TTS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         minSdk = 29
         targetSdk = 35
         versionCode = 1
-        versionName = "0.4"
+        versionName = "0.05"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -356,7 +356,17 @@ fun MainScreen(
                     icon = { Icon(Icons.Default.MenuBook, contentDescription = "Book") },
                     label = { Text("Book") },
                     selected = currentScreen == Screen.Book,
-                    onClick = { currentScreen = Screen.Book }
+                    onClick = {
+                        if (SettingsManager.getTtsEngine(context) == TtsEngine.KITTEN) {
+                            Toast.makeText(
+                                context,
+                                "Book activity is disabled when using the Kitten TTS engine.",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        } else {
+                            currentScreen = Screen.Book
+                        }
+                    }
                 )
                 NavigationBarItem(
                     icon = { Icon(Icons.Filled.RecordVoiceOver, contentDescription = "Chat TTS") }, // Example new icon

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -3,6 +3,7 @@ package com.example.nabu.screens
 import ai.onnxruntime.OrtSession
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -47,6 +48,23 @@ fun BookScreen(
     val scope = rememberCoroutineScope()
 
     val engine by rememberUpdatedState(SettingsManager.getTtsEngine(context))
+
+    if (engine == TtsEngine.KITTEN) {
+        LaunchedEffect(Unit) {
+            Toast.makeText(
+                context,
+                "Book activity is disabled when using the Kitten TTS engine.",
+                Toast.LENGTH_LONG
+            ).show()
+        }
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Book activity is disabled when using the Kitten TTS engine.")
+        }
+        return
+    }
 
     LaunchedEffect(engine) {
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {


### PR DESCRIPTION
## Summary
- bump app version to 0.05
- show message and block Book screen when Kitten TTS is selected

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a29a1b6e488331b8441d10cad0ff72