### PR TITLE
Adopt brutalist UI for basic and mixer screens

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -36,20 +36,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.MoreHoriz
-import androidx.compose.material.icons.filled.RecordVoiceOver
-import androidx.compose.material.icons.filled.MenuBook
-import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -339,40 +329,38 @@ fun MainScreen(
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {
-            NavigationBar {
-                NavigationBarItem(
-                    icon = { Icon(Icons.Default.Home, contentDescription = "Basic") },
-                    label = { Text("Basic") },
-                    selected = currentScreen == Screen.Basic,
-                    onClick = { currentScreen = Screen.Basic }
-                )
-                NavigationBarItem(
-                    icon = { Icon(Icons.Default.VolumeUp, contentDescription = "Mixer") },
-                    label = { Text("Mixer") },
-                    selected = currentScreen == Screen.Mixer,
-                    onClick = { currentScreen = Screen.Mixer }
-                )
-                NavigationBarItem(
-                    icon = { Icon(Icons.Default.MenuBook, contentDescription = "Book") },
-                    label = { Text("Book") },
-                    selected = currentScreen == Screen.Book,
-                    onClick = { currentScreen = Screen.Book }
-                )
-                NavigationBarItem(
-                    icon = { Icon(Icons.Filled.RecordVoiceOver, contentDescription = "Chat TTS") }, // Example new icon
-                    label = { Text("Chat TTS") },
-                    selected = currentScreen == Screen.ChatTts, // For selection state
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                BrutalButton(
+                    onClick = { currentScreen = Screen.Basic },
+                    modifier = Modifier.weight(1f),
+                    enabled = currentScreen != Screen.Basic
+                ) { Text("BASIC") }
+                BrutalButton(
+                    onClick = { currentScreen = Screen.Mixer },
+                    modifier = Modifier.weight(1f),
+                    enabled = currentScreen != Screen.Mixer
+                ) { Text("MIXER") }
+                BrutalButton(
+                    onClick = { currentScreen = Screen.Book },
+                    modifier = Modifier.weight(1f),
+                    enabled = currentScreen != Screen.Book
+                ) { Text("BOOK") }
+                BrutalButton(
                     onClick = {
                         context.startActivity(Intent(context, ChatTtsActivity::class.java))
-                        // currentScreen = Screen.ChatTts // If you want to try and reflect selection
-                    }
-                )
-                NavigationBarItem(
-                    icon = { Icon(Icons.Default.MoreHoriz, contentDescription = "More") },
-                    label = { Text("More") },
-                    selected = currentScreen == Screen.More,
-                    onClick = { currentScreen = Screen.More }
-                )
+                    },
+                    modifier = Modifier.weight(1f)
+                ) { Text("CHAT TTS") }
+                BrutalButton(
+                    onClick = { currentScreen = Screen.More },
+                    modifier = Modifier.weight(1f),
+                    enabled = currentScreen != Screen.More
+                ) { Text("MORE") }
             }
         }
     ) { innerPadding ->
@@ -454,7 +442,7 @@ fun BasicScreen(
             minLines = 3,
             maxLines = 12,
             onValueChange = { text = it },
-            label = { Text("Text to speak") },
+            label = { Text("TEXT TO SPEAK") },
             modifier = Modifier.fillMaxWidth(),
             keyboardOptions = KeyboardOptions.Default.copy(
                 keyboardType = KeyboardType.Text
@@ -469,13 +457,13 @@ fun BasicScreen(
             TextField(
                 value = engine.name,
                 onValueChange = {},
-                label = { Text("TTS Engine") },
+                label = { Text("TTS ENGINE") },
                 modifier = Modifier
                     .fillMaxWidth()
                     .menuAnchor(),
                 readOnly = true,
                 trailingIcon = {
-                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = engineExpanded)
+                    Text(if (engineExpanded) "▲" else "▼", color = Brutal.textBright)
                 }
             )
 
@@ -485,7 +473,7 @@ fun BasicScreen(
             ) {
                 TtsEngine.values().forEach { option ->
                     DropdownMenuItem(
-                        text = { Text(option.name) },
+                        text = { Text(option.name.uppercase()) },
                         onClick = {
                             engine = option
                             SettingsManager.setTtsEngine(context, option)
@@ -507,13 +495,13 @@ fun BasicScreen(
                     style = it
                     SettingsManager.setStyle(context, it)
                 },
-                label = { Text("Style") },
+                label = { Text("STYLE") },
                 modifier = Modifier
                     .fillMaxWidth()
                     .menuAnchor(),
                 readOnly = true,
                 trailingIcon = {
-                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                    Text(if (expanded) "▲" else "▼", color = Brutal.textBright)
                 }
             )
 
@@ -523,7 +511,7 @@ fun BasicScreen(
             ) {
                 names.forEach { name ->
                     DropdownMenuItem(
-                        text = { Text(name) },
+                        text = { Text(name.uppercase()) },
                         onClick = {
                             style = name
                             SettingsManager.setStyle(context, name)
@@ -539,7 +527,7 @@ fun BasicScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Raw text input")
+                Text("RAW TEXT INPUT")
                 Spacer(modifier = Modifier.width(8.dp))
                 Switch(checked = useRawText, onCheckedChange = { useRawText = it })
             }
@@ -576,7 +564,7 @@ fun BasicScreen(
                     .weight(1f),
                 enabled = !isProcessing
             ) {
-                Text(if (isProcessing) "GPU Processing..." else "Play")
+                Text(if (isProcessing) "GPU PROCESSING..." else "PLAY")
             }
 
             Spacer(modifier = Modifier.width(12.dp))
@@ -594,7 +582,7 @@ fun BasicScreen(
                     .weight(1f),
                 enabled = !isProcessing
             ) {
-                Text(if (isProcessing) "GPU Processing..." else "Play & Save")
+                Text(if (isProcessing) "GPU PROCESSING..." else "PLAY & SAVE")
             }
         }
     }

--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
@@ -332,7 +333,8 @@ fun MainScreen(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(8.dp),
+                    .navigationBarsPadding()
+                    .padding(start = 8.dp, top = 8.dp, end = 8.dp, bottom = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 BrutalButton(

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -22,16 +22,12 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -43,7 +39,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -120,7 +115,7 @@ fun MixerScreen(
             onValueChange = { text = it },
             minLines = 3,
             maxLines = 12,
-            label = { Text("Text to speak") },
+            label = { Text("TEXT TO SPEAK") },
             modifier = Modifier.fillMaxWidth()
             )
 
@@ -192,7 +187,7 @@ fun MixerScreen(
                 },
                 modifier = Modifier.weight(1f),
                 enabled = !isProcessing
-            ) { Text(if (isProcessing) "Mixing..." else "Play") }
+            ) { Text(if (isProcessing) "MIXING..." else "PLAY") }
 
             BrutalButton(
                 onClick = {
@@ -217,7 +212,7 @@ fun MixerScreen(
                 },
                 modifier = Modifier.weight(1f),
                 enabled = !isProcessing
-            ) { Text(if (isProcessing) "Mixing..." else "Play & Save") }
+            ) { Text(if (isProcessing) "MIXING..." else "PLAY & SAVE") }
         }
 
         // Debug logs moved to dedicated screen
@@ -311,7 +306,7 @@ fun StyleSelector(
 
     Column {
         Text(
-            "Selected Styles:",
+            "SELECTED STYLES:",
             style = MaterialTheme.typography.labelLarge,
             color = Brutal.textBright
         )
@@ -323,14 +318,7 @@ fun StyleSelector(
             selectedStyles.forEach { style ->
                 SuggestionChip(
                     onClick = { onRemoveStyle(style) },
-                    label = { Text(style, color = Brutal.textBright) },
-                    icon = {
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = "Remove",
-                            tint = Brutal.textBright
-                        )
-                    },
+                    label = { Text(style.uppercase(), color = Brutal.textBright) },
                     colors = SuggestionChipDefaults.suggestionChipColors(
                         containerColor = Brutal.panelBg,
                         iconContentColor = Brutal.textBright,
@@ -351,14 +339,9 @@ fun StyleSelector(
                 onValueChange = {},
                 readOnly = true,
                 trailingIcon = {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = null,
-                        tint = Brutal.textBright,
-                        modifier = Modifier.graphicsLayer(rotationZ = if (expanded) 180f else 0f)
-                    )
+                    Text(if (expanded) "▲" else "▼", color = Brutal.textBright)
                 },
-                placeholder = { Text("Add style...", color = Brutal.textDim) },
+                placeholder = { Text("ADD STYLE...", color = Brutal.textDim) },
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Brutal.panelBg,
                     unfocusedContainerColor = Brutal.panelBg,
@@ -386,7 +369,7 @@ fun StyleSelector(
             ) {
                 styleNames.filter { it !in selectedStyles }.forEach { style ->
                     DropdownMenuItem(
-                        text = { Text(style, color = Brutal.textBright) },
+                        text = { Text(style.uppercase(), color = Brutal.textBright) },
                         onClick = {
                             onAddStyle(style)
                             expanded = false
@@ -406,7 +389,7 @@ fun WeightSliders(
     onWeightChanged: (String, Float) -> Unit
 ) {
     Column {
-        Text("Style Weights:", style = MaterialTheme.typography.labelLarge)
+        Text("STYLE WEIGHTS:", style = MaterialTheme.typography.labelLarge, color = Brutal.textBright)
 
         selectedStyles.forEach { style ->
             PanelRow(name = style) {
@@ -427,7 +410,7 @@ fun InterpolationModeSelector(
     onModeSelected: (InterpolationMode) -> Unit
 ) {
     Column {
-        Text("Interpolation Mode:", style = MaterialTheme.typography.labelLarge)
+        Text("INTERPOLATION MODE:", style = MaterialTheme.typography.labelLarge, color = Brutal.textBright)
 
         Row(horizontalArrangement = Arrangement.SpaceEvenly) {
             InterpolationMode.entries.forEach { mode ->
@@ -441,7 +424,7 @@ fun InterpolationModeSelector(
                         selected = currentMode == mode,
                         onClick = { onModeSelected(mode) }
                     )
-                    Text(mode.displayName)
+                    Text(mode.displayName.uppercase())
                 }
             }
         }

--- a/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
+++ b/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
@@ -12,10 +12,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Divider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.ProvideTextStyle
@@ -29,7 +26,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
@@ -138,11 +134,9 @@ fun BrutalSection(
                 style = MaterialTheme.typography.titleMedium
             )
             Spacer(Modifier.weight(1f))
-            Icon(
-                imageVector = Icons.Default.ArrowDropDown,
-                contentDescription = "Toggle $title",
-                tint = Brutal.textBright,
-                modifier = Modifier.graphicsLayer(rotationZ = if (expanded) 180f else 0f)
+            Text(
+                if (expanded) "▲" else "▼",
+                color = Brutal.textBright
             )
         }
         if (expanded) {


### PR DESCRIPTION
## Summary
- Replace bottom navigation with brutalist buttons using all-caps labels
- Drop material icons and use text-based arrows in basic and mixer screens
- Remove material arrow icon from brutalist section component

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cbeef8988331abee424cfa189b2f