### PR TITLE
Rename Chat TTS to Chat and apply brutalist UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ChatTtsActivity"
+            android:name=".ChatActivity"
             android:exported="true"
             android:theme="@style/AppTheme"
             android:forceDarkAllowed="true"

--- a/app/src/main/java/com/example/nabu/ChatActivity.kt
+++ b/app/src/main/java/com/example/nabu/ChatActivity.kt
@@ -12,15 +12,15 @@ import androidx.lifecycle.ViewModelProvider
 import com.example.kokoro.chat.LlmInference
 import com.example.nabu.data.ModelManager
 import com.example.nabu.data.Model
-import com.example.nabu.screens.ChatTtsScreen
+import com.example.nabu.screens.ChatScreen
 import com.example.nabu.utils.OnnxRuntimeManager
 import com.example.nabu.utils.DebugLogger
 import com.example.nabu.utils.SettingsManager
 import com.example.kokoro.galleryport.PerfHud
-import com.example.nabu.viewmodel.ChatTtsViewModel
+import com.example.nabu.viewmodel.ChatViewModel
 import java.io.File
 
-class ChatTtsActivity : ComponentActivity() {
+class ChatActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         DebugLogger.initialize(this)
@@ -68,12 +68,12 @@ class ChatTtsActivity : ComponentActivity() {
         val modelFile = File(filesDir, "models/${model.id}.task")
         val llmInference = LlmInference(applicationContext, modelFile.absolutePath)
 
-        val viewModel: ChatTtsViewModel by viewModels {
+        val viewModel: ChatViewModel by viewModels {
             object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                    if (modelClass.isAssignableFrom(ChatTtsViewModel::class.java)) {
+                    if (modelClass.isAssignableFrom(ChatViewModel::class.java)) {
                         @Suppress("UNCHECKED_CAST")
-                        return ChatTtsViewModel(applicationContext, session, llmInference) as T
+                        return ChatViewModel(applicationContext, session, llmInference) as T
                     }
                     throw IllegalArgumentException("Unknown ViewModel class")
                 }
@@ -82,8 +82,8 @@ class ChatTtsActivity : ComponentActivity() {
 
         setContent {
             NabuTheme {
-                ChatTtsScreen(viewModel = viewModel)
-                if (SettingsManager.isBenchmark(this@ChatTtsActivity)) {
+                ChatScreen(viewModel = viewModel)
+                if (SettingsManager.isBenchmark(this@ChatActivity)) {
                     PerfHud.Overlay()
                 }
             }

--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -294,7 +294,7 @@ private fun screenFromString(name: String?): Screen = when (name) {
     "Basic" -> Screen.Basic
     "Mixer" -> Screen.Mixer
     "Book" -> Screen.Book
-    "ChatTts" -> Screen.ChatTts
+    "Chat" -> Screen.Chat
     "More" -> Screen.More
     "Creations" -> Screen.Creations
     "Settings" -> Screen.Settings
@@ -307,7 +307,7 @@ sealed class Screen {
     object Basic : Screen()
     object Mixer : Screen()
     object Book : Screen()
-    object ChatTts : Screen() // New screen state for ChatTtsActivity if needed for selection
+    object Chat : Screen() // New screen state for ChatActivity if needed for selection
     object More : Screen()
     object Creations : Screen()
     object Settings : Screen()
@@ -354,10 +354,10 @@ fun MainScreen(
                 ) { Text("BOOK") }
                 BrutalButton(
                     onClick = {
-                        context.startActivity(Intent(context, ChatTtsActivity::class.java))
+                        context.startActivity(Intent(context, ChatActivity::class.java))
                     },
                     modifier = Modifier.weight(1f)
-                ) { Text("CHAT TTS") }
+                ) { Text("CHAT") }
                 BrutalButton(
                     onClick = { currentScreen = Screen.More },
                     modifier = Modifier.weight(1f),
@@ -377,8 +377,8 @@ fun MainScreen(
                     session = session,
                     phonemeConverter = phonemeConverter
                 )
-                Screen.ChatTts -> {
-                    // No-op, handled by onClick which starts ChatTtsActivity
+                Screen.Chat -> {
+                    // No-op, handled by onClick which starts ChatActivity
                     // This case is primarily for the 'selected' state of the NavigationBarItem
                 }
                 Screen.More -> MoreScreen { screen ->

--- a/app/src/main/java/com/example/nabu/screens/ChatScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatScreen.kt
@@ -1,5 +1,6 @@
 package com.example.nabu.screens
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,14 +19,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -40,16 +40,16 @@ import com.mewmix.nabu.ui.brutalist.PanelBox
 import com.mewmix.nabu.ui.brutalist.BrutalSection
 import com.mewmix.nabu.ui.brutalist.Brutal
 import com.mewmix.nabu.ui.brutalist.BrutalButton
+import com.mewmix.nabu.ui.brutalist.BrutalSlider
 import com.example.kokoro.chat.MessageBubble
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PcmTap
-import com.example.nabu.viewmodel.ChatTtsViewModel
+import com.example.nabu.viewmodel.ChatViewModel
 import com.example.nabu.ui.components.WaveformVisualizer
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChatTtsScreen(
-    viewModel: ChatTtsViewModel
+fun ChatScreen(
+    viewModel: ChatViewModel
 ) {
     val chatMessages by viewModel.chatMessages.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -111,11 +111,11 @@ fun ChatTtsScreen(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Text("Speed: ${"%.2f".format(speed)}", color = Brutal.textBright)
-                    Slider(
+                    BrutalSlider(
                         value = speed,
                         onValueChange = { viewModel.updateSpeed(it) },
                         valueRange = 0.5f..2.0f,
-                        steps = 15,
+                        steps = 15
                     )
                 }
             }
@@ -134,9 +134,19 @@ fun ChatTtsScreen(
                         .padding(horizontal = 16.dp, vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = statusText, style = androidx.compose.material3.MaterialTheme.typography.bodySmall)
+                    Text(
+                        text = statusText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Brutal.textBright
+                    )
                     Spacer(modifier = Modifier.width(8.dp))
-                    if(isLoading || isSynthesizing) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    if (isLoading || isSynthesizing) {
+                        LinearProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = Brutal.amber,
+                            trackColor = Brutal.panelStroke
+                        )
+                    }
                 }
             }
 
@@ -167,7 +177,7 @@ fun ChatTtsScreen(
                         .padding(8.dp),
                     contentAlignment = Alignment.Center
                 ) {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(color = Brutal.amber)
                 }
             }
 
@@ -178,12 +188,26 @@ fun ChatTtsScreen(
                     .padding(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                OutlinedTextField(
+                TextField(
                     value = message,
                     onValueChange = { message = it },
-                    modifier = Modifier.weight(1f),
-                    label = { Text("Message") },
-                    shape = RoundedCornerShape(24.dp)
+                    modifier = Modifier
+                        .weight(1f)
+                        .border(1.dp, Brutal.hairline, RoundedCornerShape(24.dp)),
+                    placeholder = { Text("Message", color = Brutal.textDim) },
+                    shape = RoundedCornerShape(24.dp),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Brutal.panelBg,
+                        unfocusedContainerColor = Brutal.panelBg,
+                        focusedIndicatorColor = Brutal.hairline,
+                        unfocusedIndicatorColor = Brutal.hairline,
+                        cursorColor = Brutal.amber,
+                        focusedTextColor = Brutal.textBright,
+                        unfocusedTextColor = Brutal.textBright,
+                        focusedPlaceholderColor = Brutal.textDim,
+                        unfocusedPlaceholderColor = Brutal.textDim
+                    ),
+                    textStyle = MaterialTheme.typography.bodyLarge
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 BrutalButton(
@@ -195,7 +219,7 @@ fun ChatTtsScreen(
                     },
                     enabled = message.isNotBlank() && !isLoading && !isSynthesizing && playerState == PlayerState.IDLE
                 ) {
-                    Icon(Icons.Default.Send, contentDescription = "Send")
+                    Icon(Icons.Default.Send, contentDescription = "Send", tint = Brutal.textBright)
                 }
             }
         }

--- a/app/src/main/java/com/example/nabu/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/ChatViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.lang.StringBuilder
 
-class ChatTtsViewModel(
+class ChatViewModel(
     private val context: Context,
     private val ortSession: OrtSession,
     private val llmInference: LlmInference
@@ -113,7 +113,7 @@ class ChatTtsViewModel(
     }
 
     fun sendMessage(message: String) {
-        DebugLogger.log("ChatTtsViewModel sendMessage: $message")
+        DebugLogger.log("ChatViewModel sendMessage: $message")
         _chatMessages.value += ChatMessage(message, true)
         _isLoading.value = true
 
@@ -146,7 +146,7 @@ class ChatTtsViewModel(
                 } else {
                     viewModelScope.launch {
                         _isLoading.value = false
-                        DebugLogger.log("ChatTtsViewModel response complete")
+                        DebugLogger.log("ChatViewModel response complete")
                         processSentences(sentenceBuilder, true)
                     }
                 }

--- a/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
+++ b/core-utils/src/main/java/com/mewmix/nabu/ui/brutalist/BrutalUi.kt
@@ -545,7 +545,7 @@ fun RadialOscilloscope(
 /* ---------- Minimal usage examples ---------- */
 
 @Composable
-fun ChatTtsControls(
+fun ChatControls(
     isPlaying: Boolean,
     onTogglePlay: (Boolean) -> Unit,
     voices: List<String>,
@@ -556,7 +556,7 @@ fun ChatTtsControls(
     meter: Float,
     samples: List<Float>
 ) {
-    PanelBox(title = "Chat · TTS Controls") {
+    PanelBox(title = "Chat Controls") {
         PanelRow("Transport") {
             SwitchToggle(
                 checked = isPlaying,


### PR DESCRIPTION
## Summary
- Rename ChatTts* activity, screen, and viewmodel to Chat counterparts
- Swap "CHAT TTS" navigation entry for "CHAT" and launch new ChatActivity
- Restyle Chat screen elements with brutalist components and colors

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d735559083318f79795f3c3131e0