### PR TITLE
Update default mixer and TTS text

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -411,7 +411,7 @@ fun BasicScreen(
     val styleLoader = remember(engine) { StyleLoader(context) }
     val names = styleLoader.names.sorted()
 
-    var text by remember { mutableStateOf("This is her warm heart, her warmest kokoro, unwavering love and comfort.") }
+    var text by remember { mutableStateOf("Made with love and brought to you from outer space.") }
     var style by remember(engine) {
         mutableStateOf(
             SettingsManager.getStyle(context).takeIf { it in names }

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -83,7 +83,7 @@ fun MixerScreen(
         }
     }
 
-    var text by remember { mutableStateOf("This is her warm heart, her warmest kokoro, unwavering love and comfort.") }
+    var text by remember { mutableStateOf("Made with love and brought to you from outer space.") }
     var speed by remember { mutableFloatStateOf(SettingsManager.getSpeed(context)) }
     var isProcessing by remember { mutableStateOf(false) }
     var shouldSaveFile by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Summary
- Set default mixer text to a friendly outer-space message
- Use the same message for the Basic TTS screen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b1f3afdc8331b10872efb3143c2b