### PR TITLE
Refine playback controls and notification messaging

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -292,9 +292,39 @@ fun BookScreen(
                 BrutalButton(onClick = { launcher.launch(arrayOf("text/plain", "application/epub+zip")) }) {
                     Text("OPEN")
                 }
-                BrutalButton(
-                    onClick = {
-                        if (playerState == PlayerState.PLAYING) {
+                val startPlaybackAction = {
+                    if (playerState == PlayerState.PAUSED) {
+                        bookViewModel.audioPlayer.stop()
+                    }
+                    bookViewModel.startPlayback(
+                        session = session,
+                        phonemeConverter = phonemeConverter,
+                        styleLoader = styleLoader,
+                        selectedStyles = selectedStyles,
+                        weights = weights,
+                        mode = interpolationMode,
+                        speed = speed,
+                        units = playableUnits,
+                        startUnit = currentUnitIndex.coerceAtLeast(0),
+                        bookUri = bookUri,
+                        projectName = projectName,
+                        context = context,
+                        engine = SettingsManager.getTtsEngine(context),
+                        usePregenerated = usePregenerated,
+                        onFinished = {
+                            bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
+                            bookmark = null
+                        },
+                    )
+                }
+                when (playerState) {
+                    PlayerState.IDLE -> {
+                        BrutalButton(onClick = { startPlaybackAction() }, enabled = lines.isNotEmpty()) {
+                            Text("PLAY")
+                        }
+                    }
+                    PlayerState.PLAYING -> {
+                        BrutalButton(onClick = {
                             bookViewModel.audioPlayer.pause()
                             bookUri?.let {
                                 DebugLogger.log("Saving bookmark at line $currentUnitIndex")
@@ -312,48 +342,21 @@ fun BookScreen(
                                 ProjectManager.save(context, project)
                                 bookmark = Bookmark(currentUnitIndex)
                             }
-                        } else {
-                            if (playerState == PlayerState.PAUSED) {
-                                bookViewModel.audioPlayer.stop()
-                            }
-                            bookViewModel.startPlayback(
-                                session = session,
-                                phonemeConverter = phonemeConverter,
-                                styleLoader = styleLoader,
-                                selectedStyles = selectedStyles,
-                                weights = weights,
-                                mode = interpolationMode,
-                                speed = speed,
-                                units = playableUnits,
-                                startUnit = currentUnitIndex.coerceAtLeast(0),
-                                bookUri = bookUri,
-                                context = context,
-                                engine = SettingsManager.getTtsEngine(context),
-                                usePregenerated = usePregenerated,
-                                onFinished = {
-                                    bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                    bookmark = null
-                                },
-                            )
+                        }) {
+                            Text("PAUSE")
                         }
-                    },
-                    enabled = lines.isNotEmpty()
-                ) {
-                    Text(
-                        when (playerState) {
-                            PlayerState.IDLE -> "PLAY"
-                            PlayerState.PLAYING -> "PAUSE"
-                            PlayerState.PAUSED -> "RESUME"
+                        BrutalButton(onClick = { bookViewModel.stopPlayback() }) {
+                            Text("STOP")
                         }
-                    )
-                }
-                BrutalButton(
-                    onClick = {
-                        bookViewModel.stopPlayback()
-                    },
-                    enabled = playerState != PlayerState.IDLE
-                ) {
-                    Text("STOP")
+                    }
+                    PlayerState.PAUSED -> {
+                        BrutalButton(onClick = { startPlaybackAction() }, enabled = lines.isNotEmpty()) {
+                            Text("PLAY")
+                        }
+                        BrutalButton(onClick = { bookViewModel.stopPlayback() }) {
+                            Text("STOP")
+                        }
+                    }
                 }
                 BrutalButton(
                     onClick = {
@@ -538,6 +541,7 @@ fun BookScreen(
                                     units = playableUnits,
                                     startUnit = index,
                                     bookUri = bookUri,
+                                    projectName = projectName,
                                     context = context,
                                     engine = SettingsManager.getTtsEngine(context),
                                     usePregenerated = usePregenerated,

--- a/app/src/main/java/com/example/nabu/utils/AudioPlayerManager.kt
+++ b/app/src/main/java/com/example/nabu/utils/AudioPlayerManager.kt
@@ -2,4 +2,5 @@ package com.example.nabu.utils
 
 object AudioPlayerManager {
     var player: AudioPlayer? = null
+    var onStop: (() -> Unit)? = null
 }

--- a/app/src/main/java/com/example/nabu/utils/PlaybackNotification.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlaybackNotification.kt
@@ -12,13 +12,17 @@ import androidx.core.app.NotificationManagerCompat
 object PlaybackNotification {
     private const val CHANNEL_ID = "book_playback_channel"
     private const val NOTIFICATION_ID = 1001
+    private var target: String = ""
+    private var style: String = ""
 
-    fun show(context: Context, playing: Boolean) {
+    fun show(context: Context, playing: Boolean, target: String? = null, style: String? = null) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (context.checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) != android.content.pm.PackageManager.PERMISSION_GRANTED) {
                 return
             }
         }
+        if (target != null) this.target = target
+        if (style != null) this.style = style
         createChannel(context)
         val notification = buildNotification(context, playing)
         NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
@@ -39,8 +43,11 @@ object PlaybackNotification {
     private fun buildNotification(context: Context, playing: Boolean) =
         NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle("Book Playback")
-            .setContentText(if (playing) "Playing" else "Paused")
+            .setContentTitle("Nabu")
+            .setContentText(
+                (if (playing) "Nabu is playing" else "Nabu paused") +
+                    " $target with style ${style.uppercase()}"
+            )
             .setOngoing(playing)
             .addAction(
                 if (playing) android.R.drawable.ic_media_pause else android.R.drawable.ic_media_play,
@@ -49,6 +56,16 @@ object PlaybackNotification {
                     context,
                     0,
                     Intent(PlaybackReceiver.ACTION_TOGGLE),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+            )
+            .addAction(
+                android.R.drawable.ic_media_stop,
+                "Stop",
+                PendingIntent.getBroadcast(
+                    context,
+                    1,
+                    Intent(PlaybackReceiver.ACTION_STOP),
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
             )

--- a/app/src/main/java/com/example/nabu/utils/PlaybackNotification.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlaybackNotification.kt
@@ -60,7 +60,7 @@ object PlaybackNotification {
                 )
             )
             .addAction(
-                android.R.drawable.ic_media_stop,
+                android.R.drawable.ic_menu_close_clear_cancel,
                 "Stop",
                 PendingIntent.getBroadcast(
                     context,

--- a/app/src/main/java/com/example/nabu/utils/PlaybackReceiver.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlaybackReceiver.kt
@@ -6,19 +6,26 @@ import android.content.Intent
 
 class PlaybackReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action == ACTION_TOGGLE) {
-            val player = AudioPlayerManager.player ?: return
-            if (player.getState() == PlayerState.PLAYING) {
-                player.pause()
-                PlaybackNotification.update(context, PlayerState.PAUSED)
-            } else {
-                player.play()
-                PlaybackNotification.update(context, PlayerState.PLAYING)
+        when (intent.action) {
+            ACTION_TOGGLE -> {
+                val player = AudioPlayerManager.player ?: return
+                if (player.getState() == PlayerState.PLAYING) {
+                    player.pause()
+                    PlaybackNotification.update(context, PlayerState.PAUSED)
+                } else {
+                    player.play()
+                    PlaybackNotification.update(context, PlayerState.PLAYING)
+                }
+            }
+            ACTION_STOP -> {
+                AudioPlayerManager.onStop?.invoke()
+                PlaybackNotification.update(context, PlayerState.IDLE)
             }
         }
     }
 
     companion object {
         const val ACTION_TOGGLE = "com.example.kokoro82m.PLAYBACK_TOGGLE"
+        const val ACTION_STOP = "com.example.kokoro82m.PLAYBACK_STOP"
     }
 }

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -90,6 +90,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         units: List<PlayableUnit>,
         startUnit: Int,
         bookUri: Uri?,
+        projectName: String,
         context: Context,
         engine: TtsEngine,
         usePregenerated: Boolean,
@@ -99,7 +100,14 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         appContext = context.applicationContext
         initializeAudioPlayer(engine)
         AudioPlayerManager.player = audioPlayer
-        PlaybackNotification.show(appContext!!, true)
+        AudioPlayerManager.onStop = { stopPlayback() }
+        val target = if (projectName.isNotBlank()) {
+            projectName
+        } else {
+            bookUri?.lastPathSegment ?: "unknown"
+        }
+        val style = selectedStyles.joinToString("+") { it.uppercase() }
+        PlaybackNotification.show(appContext!!, true, target, style)
         playJob = playBook(
             scope = viewModelScope,
             session = session,
@@ -126,6 +134,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         _audioPlayer?.stop()
         appContext?.let { PlaybackNotification.cancel(it) }
         AudioPlayerManager.player = null
+        AudioPlayerManager.onStop = null
     }
 
     fun openDocument(uri: Uri) {


### PR DESCRIPTION
## Summary
- Show discrete Play, Pause, and Stop controls only during playback
- Add stop action and style-aware message to playback notification
- Wire stop broadcast to view model for proper shutdown

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b99bd11883319524afd07f685ce2