### PR TITLE
Prompt for notification permission with optional suppression

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -45,6 +45,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
 import com.mewmix.nabu.ui.brutalist.PanelBox
 import com.mewmix.nabu.ui.brutalist.BrutalButton
 import com.mewmix.nabu.ui.brutalist.BrutalSlider
@@ -133,11 +135,14 @@ class MainActivity : ComponentActivity() {
     private lateinit var phonemeConverter: PhonemeConverter
     private val scope = MainScope()
     private lateinit var userPreferencesRepository: UserPreferencesRepository
+    private var showNotificationDialog by mutableStateOf(false)
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) {
             showPlaybackNotification(this)
+        } else if (SettingsManager.shouldShowNotificationPrompt(this)) {
+            showNotificationDialog = true
         }
     }
 
@@ -178,6 +183,30 @@ class MainActivity : ComponentActivity() {
                     userPreferencesRepository = userPreferencesRepository,
                     initialScreen = startScreen
                 )
+
+                if (showNotificationDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showNotificationDialog = false },
+                        title = { Text("Enable notifications") },
+                        text = { Text("Notifications allow control of playback outside the app window.") },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                showNotificationDialog = false
+                                requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+                            }) {
+                                Text("Allow")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = {
+                                SettingsManager.setShowNotificationPrompt(this@MainActivity, false)
+                                showNotificationDialog = false
+                            }) {
+                                Text("Don't show again")
+                            }
+                        }
+                    )
+                }
 
                 if (SettingsManager.isBenchmark(this@MainActivity)) {
                     PerfHud.Overlay()

--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -13,8 +13,6 @@ import com.example.nabu.screens.CreditsConstellationScreen
 import com.example.kokoro.galleryport.PerfHud
 import ai.onnxruntime.OrtSession
 import android.app.Application
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -22,10 +20,10 @@ import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,7 +44,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.AlertDialogDefaults
 import com.mewmix.nabu.ui.brutalist.PanelBox
 import com.mewmix.nabu.ui.brutalist.BrutalButton
 import com.mewmix.nabu.ui.brutalist.BrutalSlider
@@ -65,7 +63,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
-import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.nabu.data.UserPreferencesRepository
@@ -91,8 +88,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 const val EXTRA_START_SCREEN = "start_screen"
-private const val PLAYBACK_CHANNEL_ID = "playback_channel"
-private const val PLAYBACK_NOTIFICATION_ID = 1
 
 class MyApplication : Application() {
     override fun onCreate() {
@@ -101,35 +96,6 @@ class MyApplication : Application() {
     }
 }
 
-private fun showPlaybackNotification(context: Context) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-        ContextCompat.checkSelfPermission(
-            context,
-            android.Manifest.permission.POST_NOTIFICATIONS
-        ) != PackageManager.PERMISSION_GRANTED
-    ) {
-        return
-    }
-
-    val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        val channel = NotificationChannel(
-            PLAYBACK_CHANNEL_ID,
-            "Playback",
-            NotificationManager.IMPORTANCE_LOW
-        )
-        manager.createNotificationChannel(channel)
-    }
-
-    val notification = NotificationCompat.Builder(context, PLAYBACK_CHANNEL_ID)
-        .setSmallIcon(android.R.drawable.ic_media_play)
-        .setContentTitle("Playback")
-        .setContentText("Audio playback in progress")
-        .setOngoing(true)
-        .build()
-
-    manager.notify(PLAYBACK_NOTIFICATION_ID, notification)
-}
 
 class MainActivity : ComponentActivity() {
     private lateinit var phonemeConverter: PhonemeConverter
@@ -139,9 +105,7 @@ class MainActivity : ComponentActivity() {
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { isGranted ->
-        if (isGranted) {
-            showPlaybackNotification(this)
-        } else if (SettingsManager.shouldShowNotificationPrompt(this)) {
+        if (!isGranted && SettingsManager.shouldShowNotificationPrompt(this)) {
             showNotificationDialog = true
         }
     }
@@ -181,7 +145,8 @@ class MainActivity : ComponentActivity() {
                         )
                     },
                     userPreferencesRepository = userPreferencesRepository,
-                    initialScreen = startScreen
+                    initialScreen = startScreen,
+                    requestNotificationPermission = ::maybeRequestNotificationPermission
                 )
 
                 if (showNotificationDialog) {
@@ -190,21 +155,26 @@ class MainActivity : ComponentActivity() {
                         title = { Text("Enable notifications") },
                         text = { Text("Notifications allow control of playback outside the app window.") },
                         confirmButton = {
-                            TextButton(onClick = {
+                            BrutalButton(onClick = {
                                 showNotificationDialog = false
                                 requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
                             }) {
-                                Text("Allow")
+                                Text("ALLOW")
                             }
                         },
                         dismissButton = {
-                            TextButton(onClick = {
+                            BrutalButton(onClick = {
                                 SettingsManager.setShowNotificationPrompt(this@MainActivity, false)
                                 showNotificationDialog = false
                             }) {
-                                Text("Don't show again")
+                                Text("DON'T SHOW AGAIN")
                             }
-                        }
+                        },
+                        colors = AlertDialogDefaults.dialogColors(
+                            containerColor = Brutal.panelBg,
+                            titleContentColor = Brutal.textBright,
+                            textContentColor = Brutal.textBright
+                        )
                     )
                 }
 
@@ -297,11 +267,9 @@ private fun generateAudio(
             playAudio(
                 audioData,
                 sampleRate,
-                scope,
-                onComplete = onComplete
-            )
-
-            showPlaybackNotification(context)
+                context,
+                scope
+            ) {}
 
             if (shouldSave) {
                 saveAudio(audioData, context, style, sampleRate)
@@ -352,7 +320,8 @@ fun MainScreen(
     phonemeConverter: PhonemeConverter,
     onGenerateAudio: (String, String, Float, Boolean, Boolean, () -> Unit) -> Unit,
     userPreferencesRepository: UserPreferencesRepository,
-    initialScreen: Screen = Screen.Basic
+    initialScreen: Screen = Screen.Basic,
+    requestNotificationPermission: () -> Unit
 ) {
     var currentScreen by remember { mutableStateOf(initialScreen) }
     val context = LocalContext.current
@@ -400,7 +369,8 @@ fun MainScreen(
                 Screen.Basic -> BasicScreen(onGenerateAudio = onGenerateAudio)
                 Screen.Mixer -> MixerScreen(
                     phonemeConverter = phonemeConverter,
-                    styleLoader = StyleLoader(context)
+                    styleLoader = StyleLoader(context),
+                    requestNotificationPermission = requestNotificationPermission
                 )
                 Screen.Book -> BookScreen(
                     session = session,

--- a/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/MixerScreen.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.withContext
 fun MixerScreen(
     phonemeConverter: PhonemeConverter,
     styleLoader: StyleLoader,
+    requestNotificationPermission: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -167,6 +168,7 @@ fun MixerScreen(
         Row(modifier = Modifier.fillMaxWidth()) {
             BrutalButton(
                 onClick = {
+                    requestNotificationPermission()
                     shouldSaveFile = false
                     isProcessing = true
                     scope.launch {
@@ -191,6 +193,7 @@ fun MixerScreen(
 
             BrutalButton(
                 onClick = {
+                    requestNotificationPermission()
                     shouldSaveFile = true
                     isProcessing = true
                     scope.launch {
@@ -271,7 +274,7 @@ private fun generateAudio(
             if (shouldSaveFile && fileName != null) {
                 saveAudio(audio, context, fileName, sampleRate)
             }
-            playAudio(audio, sampleRate, scope) {}
+            playAudio(audio, sampleRate, context, scope) {}
         } catch (e: Exception) {
             DebugLogger.log("Mixer error: ${e.message}")
         } finally {

--- a/app/src/main/java/com/example/nabu/utils/PlayAudio.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlayAudio.kt
@@ -4,6 +4,7 @@ import android.media.AudioFormat
 import android.media.AudioFormat.CHANNEL_OUT_MONO
 import android.media.AudioManager
 import android.media.AudioTrack
+import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -12,8 +13,16 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.min
 
-fun playAudio(audioData: FloatArray, sampleRate: Int, scope: CoroutineScope, onComplete: () -> Unit) {
+fun playAudio(
+    audioData: FloatArray,
+    sampleRate: Int,
+    context: Context,
+    scope: CoroutineScope,
+    onComplete: () -> Unit
+) {
     scope.launch(Dispatchers.IO) {
+        PlaybackNotificationManager.show(context)
+
         val channelConfig = CHANNEL_OUT_MONO
         val audioFormat = AudioFormat.ENCODING_PCM_16BIT
         val bufferSize = AudioTrack.getMinBufferSize(sampleRate, channelConfig, audioFormat)
@@ -56,6 +65,8 @@ fun playAudio(audioData: FloatArray, sampleRate: Int, scope: CoroutineScope, onC
 
         audioTrack.stop()
         audioTrack.release()
+
+        PlaybackNotificationManager.hide(context)
 
         withContext(Dispatchers.Main) {
             onComplete()

--- a/app/src/main/java/com/example/nabu/utils/PlaybackNotificationManager.kt
+++ b/app/src/main/java/com/example/nabu/utils/PlaybackNotificationManager.kt
@@ -1,0 +1,50 @@
+package com.example.nabu.utils
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+
+object PlaybackNotificationManager {
+    private const val CHANNEL_ID = "playback_channel"
+    private const val NOTIFICATION_ID = 1
+
+    fun show(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Playback",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            manager.createNotificationChannel(channel)
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentTitle("Playback")
+            .setContentText("Audio playback in progress")
+            .setOngoing(true)
+            .build()
+
+        manager.notify(NOTIFICATION_ID, notification)
+    }
+
+    fun hide(context: Context) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.cancel(NOTIFICATION_ID)
+    }
+}
+

--- a/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
@@ -39,4 +39,11 @@ object SettingsManager {
         DatabaseManager.getSetting(context, "tts_engine")?.let {
             runCatching { TtsEngine.valueOf(it) }.getOrNull()
         } ?: default
+
+    fun setShowNotificationPrompt(context: Context, show: Boolean) {
+        DatabaseManager.setSetting(context, "show_notification_prompt", if (show) "1" else "0")
+    }
+
+    fun shouldShowNotificationPrompt(context: Context): Boolean =
+        (DatabaseManager.getSetting(context, "show_notification_prompt") ?: "1") == "1"
 }


### PR DESCRIPTION
## Summary
- Show dialog when notification permission denied with option to enable or suppress further prompts
- Persist "don't show again" choice via SettingsManager

## Testing
- `gradle app:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c8a279048331867bdbbd498e4ed7