### PR TITLE
Add persistent voice toggle and playback interruption controls

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/ChatScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/ChatScreen.kt
@@ -19,6 +19,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -60,6 +63,7 @@ fun ChatScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val isSynthesizing by viewModel.isSynthesizing.collectAsState()
     val playerState by viewModel.playerState.collectAsState()
+    val ttsEnabled by viewModel.ttsEnabled.collectAsState()
     val conversationSummaries by viewModel.conversationSummaries.collectAsState()
     val activeConversationId by viewModel.activeConversationId.collectAsState()
     val availableModels by viewModel.availableModels.collectAsState()
@@ -188,6 +192,41 @@ fun ChatScreen(
                             enabled = activeConversationId != null
                         ) {
                             Text("Delete", color = Brutal.red)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val voiceColor = if (ttsEnabled) Brutal.textBright else Brutal.textDim
+                        BrutalButton(
+                            onClick = { viewModel.toggleTtsEnabled() },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Icon(
+                                imageVector = if (ttsEnabled) Icons.Filled.VolumeUp else Icons.Filled.VolumeOff,
+                                contentDescription = if (ttsEnabled) "Disable voice playback" else "Enable voice playback",
+                                tint = voiceColor
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = if (ttsEnabled) "Voice On" else "Voice Off",
+                                color = voiceColor
+                            )
+                        }
+                        BrutalButton(
+                            onClick = { viewModel.stopPlayback() },
+                            enabled = playerState == PlayerState.PLAYING || isSynthesizing
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Stop,
+                                contentDescription = "Stop voice playback",
+                                tint = Brutal.red
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Stop", color = Brutal.red)
                         }
                     }
                     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
+++ b/app/src/main/java/com/example/nabu/utils/SettingsManager.kt
@@ -39,4 +39,13 @@ object SettingsManager {
         DatabaseManager.getSetting(context, "tts_engine")?.let {
             runCatching { TtsEngine.valueOf(it) }.getOrNull()
         } ?: default
+
+    fun setTtsEnabled(context: Context, enabled: Boolean) {
+        DatabaseManager.setSetting(context, "tts_enabled", if (enabled) "1" else "0")
+    }
+
+    fun isTtsEnabled(context: Context, default: Boolean = true): Boolean {
+        val fallback = if (default) "1" else "0"
+        return (DatabaseManager.getSetting(context, "tts_enabled") ?: fallback) == "1"
+    }
 }

--- a/app/src/main/java/com/example/nabu/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/ChatViewModel.kt
@@ -32,6 +32,7 @@ import com.example.nabu.utils.createKittenAudioFromStyleVector
 import com.example.nabu.utils.mixStyles
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.tryReceive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -97,7 +98,7 @@ class ChatViewModel(
     private val _playerState = MutableStateFlow(PlayerState.IDLE)
     val playerState = _playerState.asStateFlow()
 
-    private val _ttsEnabled = MutableStateFlow(true)
+    private val _ttsEnabled = MutableStateFlow(SettingsManager.isTtsEnabled(context))
     val ttsEnabled = _ttsEnabled.asStateFlow()
 
     // Mixer State
@@ -114,24 +115,29 @@ class ChatViewModel(
     val speed = _speed.asStateFlow()
 
     private val audioQueue = Channel<Pair<Int, FloatArray>>(Channel.UNLIMITED)
+    private val pendingAudio = mutableMapOf<Int, FloatArray>()
+    private var nextPlaybackIndex = 0
+    private var dropQueuedAudio = false
     private var lineIndex = 0
 
     init {
         // Launch a coroutine to play queued audio in the order they were generated
         viewModelScope.launch {
-            val pending = mutableMapOf<Int, FloatArray>()
-            var nextIndex = 0
             for ((index, audio) in audioQueue) {
-                pending[index] = audio
-                while (pending.containsKey(nextIndex)) {
-                    val data = pending.remove(nextIndex)!!
+                pendingAudio[index] = audio
+                while (pendingAudio.containsKey(nextPlaybackIndex)) {
+                    val data = pendingAudio.remove(nextPlaybackIndex)!!
+                    if (!_ttsEnabled.value || dropQueuedAudio) {
+                        nextPlaybackIndex++
+                        continue
+                    }
                     try {
                         audioPlayer.prepare(data)
                         audioPlayer.playBlocking()
                     } catch (e: Exception) {
                         DebugLogger.log("Audio playback error: ${e.localizedMessage}")
                     }
-                    nextIndex++
+                    nextPlaybackIndex++
                 }
             }
         }
@@ -147,9 +153,21 @@ class ChatViewModel(
     fun toggleTtsEnabled() {
         val enabled = !_ttsEnabled.value
         _ttsEnabled.value = enabled
+        SettingsManager.setTtsEnabled(context, enabled)
         if (!enabled) {
-            audioPlayer.stop()
+            stopPlayback()
+        } else {
+            dropQueuedAudio = false
         }
+    }
+
+    fun stopPlayback() {
+        dropQueuedAudio = true
+        pendingAudio.clear()
+        drainAudioQueue()
+        audioPlayer.stop()
+        _playerState.value = PlayerState.IDLE
+        _isSynthesizing.value = false
     }
 
     fun selectConversation(conversationId: Long) {
@@ -211,6 +229,7 @@ class ChatViewModel(
             return
         }
 
+        dropQueuedAudio = false
         DebugLogger.log("ChatViewModel sendMessage: $trimmed")
         _chatMessages.value += ChatMessage(trimmed, true)
         conversationHistory.add(ConversationTurn(ConversationRole.USER, trimmed))
@@ -354,8 +373,10 @@ class ChatViewModel(
 
     private fun clearPendingAudio() {
         lineIndex = 0
-        // Note: Draining the Channel without coroutines channel helpers available.
-        // We skip explicit draining to avoid unresolved reference issues during build.
+        nextPlaybackIndex = 0
+        pendingAudio.clear()
+        dropQueuedAudio = false
+        drainAudioQueue()
         audioPlayer.stop()
         _playerState.value = PlayerState.IDLE
         _isSynthesizing.value = false
@@ -484,10 +505,13 @@ class ChatViewModel(
             builder.clear()
             synthesizeAndQueue(cleanText(sentence))
         }
+        if (done) {
+            dropQueuedAudio = false
+        }
     }
 
     private fun synthesizeAndQueue(text: String) {
-        if (!_ttsEnabled.value) return
+        if (!_ttsEnabled.value || dropQueuedAudio) return
         val currentIndex = lineIndex++
         viewModelScope.launch {
             _isSynthesizing.value = true
@@ -531,12 +555,21 @@ class ChatViewModel(
                     }
                     data
                 }
-                audioQueue.send(currentIndex to audioData)
+                if (!dropQueuedAudio) {
+                    audioQueue.send(currentIndex to audioData)
+                }
             } catch (e: Exception) {
                 DebugLogger.log("Error synthesizing sentence: ${e.localizedMessage}")
             } finally {
                 _isSynthesizing.value = false
             }
+        }
+    }
+
+    private fun drainAudioQueue() {
+        while (true) {
+            val result = audioQueue.tryReceive()
+            if (result.isFailure) break
         }
     }
 


### PR DESCRIPTION
## Summary
- add a voice playback toggle and stop control to the chat settings UI
- persist the user's voice playback preference through SettingsManager
- update ChatViewModel to stop playback and drop queued audio when disabled

## Testing
- ./gradlew :app:lint *(fails: Gradle wrapper missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb1439f608331adc9acb609f9fd05