### PR TITLE
Add ebook editing workflow to book screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,13 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 <!--    <uses-permission android:name="android.permission.RECORD_AUDIO" />-->
-<!--    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"-->
-<!--        android:maxSdkVersion="32" />-->
-<!--    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"-->
-<!--        android:maxSdkVersion="32"-->
-<!--        tools:ignore="ScopedStorage" />-->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
 
     <application
         android:largeHeap="true"

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -96,6 +96,48 @@ fun BookScreen(
     var saveMessage by remember { mutableStateOf<String?>(null) }
     var saveSuccessful by remember { mutableStateOf(false) }
 
+    fun startSaveEditedCopy() {
+        if (isSavingEdited) return
+        isSavingEdited = true
+        saveMessage = null
+        saveSuccessful = false
+        scope.launch {
+            try {
+                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
+                if (uri != null) {
+                    saveMessage = "Saved edited copy"
+                    saveSuccessful = true
+                } else {
+                    saveMessage = "Unable to save edited copy"
+                    saveSuccessful = false
+                }
+            } catch (e: SecurityException) {
+                saveMessage = e.localizedMessage ?: "Storage permission is required to save edited copy"
+                saveSuccessful = false
+            } catch (e: Exception) {
+                saveMessage = e.localizedMessage ?: "Failed to save edited copy"
+                saveSuccessful = false
+            } finally {
+                isSavingEdited = false
+            }
+        }
+    }
+
+    var pendingSaveRequest by remember { mutableStateOf(false) }
+    val storagePermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) {
+        val hasPermissions = StoragePermissions.hasRequiredPermissions(context)
+        if (hasPermissions && pendingSaveRequest) {
+            pendingSaveRequest = false
+            startSaveEditedCopy()
+        } else if (!hasPermissions) {
+            pendingSaveRequest = false
+            saveMessage = "Storage permission is required to save edited copy"
+            saveSuccessful = false
+        }
+    }
+
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
@@ -140,6 +182,7 @@ fun BookScreen(
         saveMessage = null
         isSavingEdited = false
         saveSuccessful = false
+        pendingSaveRequest = false
     }
 
     LaunchedEffect(currentUnitIndex, followText) {
@@ -302,7 +345,7 @@ fun BookScreen(
 
         item {
             BrutalSection(
-                title = "Ebook Editor",
+                title = "Editor",
                 expanded = showEditorSection,
                 onToggle = { showEditorSection = !showEditorSection }
             ) {
@@ -367,25 +410,15 @@ fun BookScreen(
                 )
                 BrutalButton(
                     onClick = {
-                        isSavingEdited = true
-                        saveMessage = null
-                        saveSuccessful = false
-                        scope.launch {
-                            try {
-                                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
-                                if (uri != null) {
-                                    saveMessage = "Saved edited copy"
-                                    saveSuccessful = true
-                                } else {
-                                    saveMessage = "Unable to save edited copy"
-                                    saveSuccessful = false
-                                }
-                            } catch (e: Exception) {
-                                saveMessage = e.localizedMessage ?: "Failed to save edited copy"
-                                saveSuccessful = false
-                            } finally {
-                                isSavingEdited = false
-                            }
+                        if (isSavingEdited || lines.isEmpty()) {
+                            return@BrutalButton
+                        }
+                        val permissions = StoragePermissions.requiredPermissions()
+                        if (permissions.isEmpty() || StoragePermissions.hasRequiredPermissions(context)) {
+                            startSaveEditedCopy()
+                        } else {
+                            pendingSaveRequest = true
+                            storagePermissionLauncher.launch(permissions)
                         }
                     },
                     enabled = !isSavingEdited && lines.isNotEmpty(),

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -62,6 +62,7 @@ fun BookScreen(
     val playerState by bookViewModel.playerState.collectAsState()
 
     val bookUri by bookViewModel.bookUri.collectAsState()
+    val bookDisplayName by bookViewModel.bookDisplayName.collectAsState()
     var bookmark by remember { mutableStateOf<Bookmark?>(null) }
 
     val listState = rememberLazyListState()
@@ -86,6 +87,14 @@ fun BookScreen(
     var projects by remember { mutableStateOf(listOf<Project>()) }
     val selectedLines = remember { mutableStateListOf<Int>() }
     var followText by remember { mutableStateOf(true) }
+    var showEditorSection by remember { mutableStateOf(false) }
+    var isEditMode by remember { mutableStateOf(false) }
+    var editingLineIndex by remember { mutableStateOf<Int?>(null) }
+    var editorText by remember { mutableStateOf("") }
+    var editedFileName by remember { mutableStateOf("edited_book.epub") }
+    var isSavingEdited by remember { mutableStateOf(false) }
+    var saveMessage by remember { mutableStateOf<String?>(null) }
+    var saveSuccessful by remember { mutableStateOf(false) }
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
@@ -125,11 +134,32 @@ fun BookScreen(
             }
             projects = ProjectManager.list(context)
         }
+        editingLineIndex = null
+        editorText = ""
+        isEditMode = false
+        saveMessage = null
+        isSavingEdited = false
+        saveSuccessful = false
     }
 
     LaunchedEffect(currentUnitIndex, followText) {
         if (followText && currentUnitIndex >= 0) {
             listState.animateScrollToItem(currentUnitIndex)
+        }
+    }
+
+    LaunchedEffect(bookDisplayName) {
+        val suggestion = bookDisplayName
+            ?.substringBeforeLast('.', bookDisplayName)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "${it}_edited.epub" }
+            ?: "edited_book.epub"
+        editedFileName = suggestion
+    }
+
+    LaunchedEffect(editingLineIndex, lines) {
+        editingLineIndex?.let { index ->
+            editorText = lines.getOrNull(index) ?: ""
         }
     }
 
@@ -265,6 +295,109 @@ fun BookScreen(
                             }
                         }
                     }
+                }
+            }
+        }
+
+        item {
+            BrutalSection(
+                title = "Ebook Editor",
+                expanded = showEditorSection,
+                onToggle = { showEditorSection = !showEditorSection }
+            ) {
+                SwitchToggle(
+                    checked = isEditMode,
+                    onToggle = {
+                        isEditMode = it
+                        if (!it) {
+                            editingLineIndex = null
+                            editorText = ""
+                        }
+                    },
+                    label = "Editing Mode"
+                )
+                if (isEditMode) {
+                    Text(
+                        text = if (editingLineIndex != null) {
+                            "Editing line ${editingLineIndex!! + 1}"
+                        } else {
+                            "Tap a line below to load it into the editor"
+                        },
+                        color = Brutal.textBright,
+                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
+                    )
+                    if (editingLineIndex != null) {
+                        OutlinedTextField(
+                            value = editorText,
+                            onValueChange = { editorText = it },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = 160.dp)
+                                .padding(top = dimensionResource(id = R.dimen.padding_small)),
+                            label = { Text("Line Text") },
+                            supportingText = { Text("Changes apply only when you tap Apply Change") }
+                        )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_small)),
+                            modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
+                        ) {
+                            BrutalButton(onClick = {
+                                editingLineIndex?.let { index ->
+                                    bookViewModel.updatePlayableUnitText(index, editorText)
+                                    saveMessage = "Updated line ${index + 1}"
+                                    saveSuccessful = true
+                                }
+                            }) { Text("Apply Change") }
+                            BrutalButton(onClick = {
+                                editingLineIndex?.let { index ->
+                                    editorText = lines.getOrNull(index) ?: ""
+                                }
+                            }) { Text("Reset") }
+                        }
+                    }
+                }
+                OutlinedTextField(
+                    value = editedFileName,
+                    onValueChange = { editedFileName = it },
+                    label = { Text("Edited File Name") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = dimensionResource(id = R.dimen.padding_small))
+                )
+                BrutalButton(
+                    onClick = {
+                        isSavingEdited = true
+                        saveMessage = null
+                        saveSuccessful = false
+                        scope.launch {
+                            try {
+                                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
+                                if (uri != null) {
+                                    saveMessage = "Saved edited copy"
+                                    saveSuccessful = true
+                                } else {
+                                    saveMessage = "Unable to save edited copy"
+                                    saveSuccessful = false
+                                }
+                            } catch (e: Exception) {
+                                saveMessage = e.localizedMessage ?: "Failed to save edited copy"
+                                saveSuccessful = false
+                            } finally {
+                                isSavingEdited = false
+                            }
+                        }
+                    },
+                    enabled = !isSavingEdited && lines.isNotEmpty(),
+                    modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
+                ) {
+                    Text(if (isSavingEdited) "SAVING..." else "SAVE EDITED COPY")
+                }
+                saveMessage?.let { message ->
+                    Text(
+                        text = message,
+                        color = if (saveSuccessful) Brutal.textBright else MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))
+                    )
                 }
             }
         }
@@ -554,30 +687,34 @@ fun BookScreen(
                     .fillMaxWidth()
                     .combinedClickable(
                         onClick = {
-                            if (selectedLines.contains(index)) {
-                                selectedLines.remove(index)
+                            if (isEditMode) {
+                                editingLineIndex = index
                             } else {
-                                bookViewModel.setCurrentUnitIndex(index)
-                                bookViewModel.startPlayback(
-                                    session = session,
-                                    phonemeConverter = phonemeConverter,
-                                    styleLoader = styleLoader,
-                                    selectedStyles = selectedStyles,
-                                    weights = weights,
-                                    mode = interpolationMode,
-                                    speed = speed,
-                                    units = playableUnits,
-                                    startUnit = index,
-                                    bookUri = bookUri,
-                                    projectName = projectName,
-                                    context = context,
-                                    engine = SettingsManager.getTtsEngine(context),
-                                    usePregenerated = usePregenerated,
-                                    onFinished = {
-                                        bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                        bookmark = null
-                                    },
-                                )
+                                if (selectedLines.contains(index)) {
+                                    selectedLines.remove(index)
+                                } else {
+                                    bookViewModel.setCurrentUnitIndex(index)
+                                    bookViewModel.startPlayback(
+                                        session = session,
+                                        phonemeConverter = phonemeConverter,
+                                        styleLoader = styleLoader,
+                                        selectedStyles = selectedStyles,
+                                        weights = weights,
+                                        mode = interpolationMode,
+                                        speed = speed,
+                                        units = playableUnits,
+                                        startUnit = index,
+                                        bookUri = bookUri,
+                                        projectName = projectName,
+                                        context = context,
+                                        engine = SettingsManager.getTtsEngine(context),
+                                        usePregenerated = usePregenerated,
+                                        onFinished = {
+                                            bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
+                                            bookmark = null
+                                        },
+                                    )
+                                }
                             }
                         },
                         onLongClick = {

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -99,9 +99,10 @@ fun BookScreen(
     var pendingSaveDisplayName by remember { mutableStateOf<String?>(null) }
 
     fun buildEditedDisplayName(name: String): String {
+        val currentBookDisplayName = bookDisplayName
         val trimmed = name.trim().ifBlank {
-            bookDisplayName
-                ?.substringBeforeLast('.', bookDisplayName)
+            currentBookDisplayName
+                ?.substringBeforeLast('.', currentBookDisplayName)
                 ?.takeIf { it.isNotBlank() }
                 ?.let { "${it}_edited" }
                 ?: "edited_book"

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -149,8 +149,9 @@ fun BookScreen(
     }
 
     LaunchedEffect(bookDisplayName) {
-        val suggestion = bookDisplayName
-            ?.substringBeforeLast('.', bookDisplayName)
+        val currentBookDisplayName = bookDisplayName
+        val suggestion = currentBookDisplayName
+            ?.substringBeforeLast('.', currentBookDisplayName)
             ?.takeIf { it.isNotBlank() }
             ?.let { "${it}_edited.epub" }
             ?: "edited_book.epub"

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -37,6 +37,7 @@ import com.mewmix.nabu.ui.brutalist.BrutalSlider
 import com.mewmix.nabu.ui.brutalist.SwitchToggle
 import androidx.compose.ui.unit.dp
 import com.example.nabu.ChatActivity
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
@@ -95,46 +96,48 @@ fun BookScreen(
     var isSavingEdited by remember { mutableStateOf(false) }
     var saveMessage by remember { mutableStateOf<String?>(null) }
     var saveSuccessful by remember { mutableStateOf(false) }
+    var pendingSaveDisplayName by remember { mutableStateOf<String?>(null) }
 
-    fun startSaveEditedCopy() {
-        if (isSavingEdited) return
-        isSavingEdited = true
-        saveMessage = null
-        saveSuccessful = false
+    fun buildEditedDisplayName(name: String): String {
+        val trimmed = name.trim().ifBlank {
+            bookDisplayName
+                ?.substringBeforeLast('.', bookDisplayName)
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "${it}_edited" }
+                ?: "edited_book"
+        }
+        return if (trimmed.lowercase(Locale.US).endsWith(".epub")) trimmed else "$trimmed.epub"
+    }
+
+    val saveEditedDocumentLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument(EpubWriter.MIME_TYPE)
+    ) { uri: Uri? ->
+        val displayName = pendingSaveDisplayName
+        pendingSaveDisplayName = null
+        if (uri == null || displayName == null) {
+            if (uri == null && isSavingEdited) {
+                saveMessage = "Save canceled"
+                saveSuccessful = false
+            }
+            isSavingEdited = false
+            return@rememberLauncherForActivityResult
+        }
         scope.launch {
             try {
-                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
-                if (uri != null) {
+                val saved = bookViewModel.saveEditedCopy(context, uri, displayName)
+                if (saved) {
                     saveMessage = "Saved edited copy"
                     saveSuccessful = true
                 } else {
                     saveMessage = "Unable to save edited copy"
                     saveSuccessful = false
                 }
-            } catch (e: SecurityException) {
-                saveMessage = e.localizedMessage ?: "Storage permission is required to save edited copy"
-                saveSuccessful = false
             } catch (e: Exception) {
                 saveMessage = e.localizedMessage ?: "Failed to save edited copy"
                 saveSuccessful = false
             } finally {
                 isSavingEdited = false
             }
-        }
-    }
-
-    var pendingSaveRequest by remember { mutableStateOf(false) }
-    val storagePermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) {
-        val hasPermissions = StoragePermissions.hasRequiredPermissions(context)
-        if (hasPermissions && pendingSaveRequest) {
-            pendingSaveRequest = false
-            startSaveEditedCopy()
-        } else if (!hasPermissions) {
-            pendingSaveRequest = false
-            saveMessage = "Storage permission is required to save edited copy"
-            saveSuccessful = false
         }
     }
 
@@ -182,7 +185,7 @@ fun BookScreen(
         saveMessage = null
         isSavingEdited = false
         saveSuccessful = false
-        pendingSaveRequest = false
+        pendingSaveDisplayName = null
     }
 
     LaunchedEffect(currentUnitIndex, followText) {
@@ -413,13 +416,13 @@ fun BookScreen(
                         if (isSavingEdited || lines.isEmpty()) {
                             return@BrutalButton
                         }
-                        val permissions = StoragePermissions.requiredPermissions()
-                        if (permissions.isEmpty() || StoragePermissions.hasRequiredPermissions(context)) {
-                            startSaveEditedCopy()
-                        } else {
-                            pendingSaveRequest = true
-                            storagePermissionLauncher.launch(permissions)
-                        }
+                        val displayName = buildEditedDisplayName(editedFileName)
+                        editedFileName = displayName
+                        isSavingEdited = true
+                        saveMessage = null
+                        saveSuccessful = false
+                        pendingSaveDisplayName = displayName
+                        saveEditedDocumentLauncher.launch(displayName)
                     },
                     enabled = !isSavingEdited && lines.isNotEmpty(),
                     modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
+++ b/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
@@ -1,0 +1,146 @@
+package com.example.nabu.utils
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import java.io.BufferedOutputStream
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+object EpubWriter {
+    private const val MIME_TYPE = "application/epub+zip"
+
+    fun save(context: Context, displayName: String, title: String, paragraphs: List<String>): Uri? {
+        if (paragraphs.isEmpty()) return null
+        val resolver = context.contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
+            put(MediaStore.MediaColumns.MIME_TYPE, MIME_TYPE)
+            put(
+                MediaStore.MediaColumns.RELATIVE_PATH,
+                Environment.DIRECTORY_DOCUMENTS + "/Nabu"
+            )
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
+            ?: return null
+        return try {
+            resolver.openOutputStream(uri)?.use { outputStream ->
+                writeEpub(outputStream, title.ifBlank { "Edited Book" }, paragraphs)
+            }
+            uri
+        } catch (e: Exception) {
+            resolver.delete(uri, null, null)
+            null
+        }
+    }
+
+    private fun writeEpub(outputStream: OutputStream, title: String, paragraphs: List<String>) {
+        ZipOutputStream(BufferedOutputStream(outputStream)).use { zos ->
+            writeMimetypeEntry(zos)
+            writeTextEntry(
+                zos,
+                "META-INF/container.xml",
+                containerXml
+            )
+            val bookId = UUID.randomUUID().toString()
+            val opfContent = createOpfContent(title, bookId)
+            writeTextEntry(zos, "OEBPS/content.opf", opfContent)
+            val xhtmlContent = createXhtmlContent(title, paragraphs)
+            writeTextEntry(zos, "OEBPS/content.xhtml", xhtmlContent)
+        }
+    }
+
+    private fun writeMimetypeEntry(zos: ZipOutputStream) {
+        val data = MIME_TYPE.toByteArray(StandardCharsets.US_ASCII)
+        val entry = ZipEntry("mimetype").apply {
+            method = ZipEntry.STORED
+            size = data.size.toLong()
+            compressedSize = size
+            crc = CRC32().apply { update(data) }.value
+        }
+        zos.putNextEntry(entry)
+        zos.write(data)
+        zos.closeEntry()
+    }
+
+    private fun writeTextEntry(zos: ZipOutputStream, name: String, content: String) {
+        val data = content.toByteArray(StandardCharsets.UTF_8)
+        zos.putNextEntry(ZipEntry(name))
+        zos.write(data)
+        zos.closeEntry()
+    }
+
+    private fun createOpfContent(title: String, bookId: String): String = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId" version="2.0">
+            <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <dc:title>${escapeXml(title)}</dc:title>
+                <dc:language>en</dc:language>
+                <dc:identifier id="BookId">$bookId</dc:identifier>
+                <dc:creator>Nabu Editor</dc:creator>
+            </metadata>
+            <manifest>
+                <item id="content" href="content.xhtml" media-type="application/xhtml+xml"/>
+            </manifest>
+            <spine>
+                <itemref idref="content"/>
+            </spine>
+        </package>
+    """.trimIndent()
+
+    private fun createXhtmlContent(title: String, paragraphs: List<String>): String {
+        val paragraphHtml = paragraphs.flatMap { paragraph ->
+            paragraph
+                .split(Regex("\\n{2,}"))
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .ifEmpty { listOf(paragraph.trim()) }
+        }.joinToString(separator = "\n") { para ->
+            val formatted = para.replace("\n", "<br/>")
+            "<p>${escapeXml(formatted)}</p>"
+        }
+        return """
+            <?xml version="1.0" encoding="utf-8"?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+                <head>
+                    <title>${escapeXml(title)}</title>
+                </head>
+                <body>
+                    $paragraphHtml
+                </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun escapeXml(text: String): String {
+        val builder = StringBuilder(text.length)
+        text.forEach { ch ->
+            builder.append(
+                when (ch) {
+                    '&' -> "&amp;"
+                    '<' -> "&lt;"
+                    '>' -> "&gt;"
+                    '"' -> "&quot;"
+                    '\'' -> "&#39;"
+                    else -> ch
+                }
+            )
+        }
+        return builder.toString()
+    }
+
+    private val containerXml: String = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+            <rootfiles>
+                <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+            </rootfiles>
+        </container>
+    """.trimIndent()
+}

--- a/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
+++ b/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
@@ -1,10 +1,7 @@
 package com.example.nabu.utils
 
-import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
-import android.os.Environment
-import android.provider.MediaStore
 import java.io.BufferedOutputStream
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
@@ -14,29 +11,17 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 object EpubWriter {
-    private const val MIME_TYPE = "application/epub+zip"
+    const val MIME_TYPE = "application/epub+zip"
 
-    fun save(context: Context, displayName: String, title: String, paragraphs: List<String>): Uri? {
-        if (paragraphs.isEmpty()) return null
+    fun save(context: Context, uri: Uri, title: String, paragraphs: List<String>): Boolean {
+        if (paragraphs.isEmpty()) return false
         val resolver = context.contentResolver
-        val contentValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
-            put(MediaStore.MediaColumns.MIME_TYPE, MIME_TYPE)
-            put(
-                MediaStore.MediaColumns.RELATIVE_PATH,
-                Environment.DIRECTORY_DOCUMENTS + "/Nabu"
-            )
-        }
-        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
-            ?: return null
         return try {
-            resolver.openOutputStream(uri)?.use { outputStream ->
+            resolver.openOutputStream(uri, "wt")?.use { outputStream ->
                 writeEpub(outputStream, title.ifBlank { "Edited Book" }, paragraphs)
-            }
-            uri
+            } ?: false
         } catch (e: Exception) {
-            resolver.delete(uri, null, null)
-            null
+            false
         }
     }
 

--- a/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
+++ b/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
@@ -19,6 +19,7 @@ object EpubWriter {
         return try {
             resolver.openOutputStream(uri, "wt")?.use { outputStream ->
                 writeEpub(outputStream, title.ifBlank { "Edited Book" }, paragraphs)
+                true
             } ?: false
         } catch (e: Exception) {
             false

--- a/app/src/main/java/com/example/nabu/utils/StoragePermissions.kt
+++ b/app/src/main/java/com/example/nabu/utils/StoragePermissions.kt
@@ -1,0 +1,30 @@
+package com.example.nabu.utils
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+object StoragePermissions {
+    fun requiredPermissions(): Array<String> {
+        val permissions = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
+        }
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            permissions += Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        return permissions.toTypedArray()
+    }
+
+    fun hasRequiredPermissions(context: Context): Boolean {
+        val required = requiredPermissions()
+        if (required.isEmpty()) {
+            return true
+        }
+        return required.all { permission ->
+            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+}

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -19,7 +19,6 @@ import com.example.nabu.utils.KokoroAudioPlayer
 import com.example.nabu.utils.PhonemeConverter
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PlaybackNotification
-import com.example.nabu.utils.StoragePermissions
 import com.example.nabu.utils.StyleLoader
 import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.playBook
@@ -163,17 +162,14 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         _playableUnits.value = updated
     }
 
-    suspend fun saveEditedCopy(context: Context, desiredName: String): Uri? {
-        if (!StoragePermissions.hasRequiredPermissions(context)) {
-            throw SecurityException("Storage permission not granted")
-        }
+    suspend fun saveEditedCopy(context: Context, uri: Uri, desiredName: String): Boolean {
         val units = _playableUnits.value
-        if (units.isEmpty()) return null
+        if (units.isEmpty()) return false
         val displayName = buildEditedDisplayName(desiredName)
         val title = displayName.substringBeforeLast('.').ifBlank { "Edited Book" }
         val paragraphs = combineUnitsToParagraphs(units)
         return withContext(Dispatchers.IO) {
-            EpubWriter.save(context, displayName, title, paragraphs)
+            EpubWriter.save(context, uri, title, paragraphs)
         }
     }
 

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -3,6 +3,7 @@ package com.example.nabu.viewmodel
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import ai.onnxruntime.OrtSession
@@ -11,6 +12,7 @@ import com.example.nabu.utils.AudioPlayer
 import com.example.nabu.utils.AudioPlayerManager
 import com.example.nabu.utils.ChunkFeeder
 import com.example.nabu.utils.DocumentReader
+import com.example.nabu.utils.EpubWriter
 import com.example.nabu.utils.InterpolationMode
 import com.example.nabu.utils.KittenAudioPlayer
 import com.example.nabu.utils.KokoroAudioPlayer
@@ -24,14 +26,18 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     private val _bookUri = MutableStateFlow<Uri?>(null)
     val bookUri = _bookUri.asStateFlow()
+
+    private val _bookDisplayName = MutableStateFlow<String?>(null)
+    val bookDisplayName = _bookDisplayName.asStateFlow()
 
     private val _playableUnits = MutableStateFlow<List<PlayableUnit>>(emptyList())
     val playableUnits = _playableUnits.asStateFlow()
@@ -65,6 +71,7 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
 
     fun loadBook(context: Context, uri: Uri) {
         _bookUri.value = uri
+        _bookDisplayName.value = resolveDisplayName(context, uri)
         viewModelScope.launch(Dispatchers.IO) {
             val units = DocumentReader
                 .asPlayableUnits(context, uri)
@@ -144,5 +151,62 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
 
     fun stopReading() {
         ChunkFeeder.stop()
+    }
+
+    fun updatePlayableUnitText(index: Int, newText: String) {
+        val currentUnits = _playableUnits.value
+        if (index !in currentUnits.indices) return
+        val updated = currentUnits.toMutableList()
+        val existing = updated[index]
+        updated[index] = existing.copy(text = newText)
+        _playableUnits.value = updated
+    }
+
+    suspend fun saveEditedCopy(context: Context, desiredName: String): Uri? {
+        val units = _playableUnits.value
+        if (units.isEmpty()) return null
+        val displayName = buildEditedDisplayName(desiredName)
+        val title = displayName.substringBeforeLast('.').ifBlank { "Edited Book" }
+        val paragraphs = combineUnitsToParagraphs(units)
+        return withContext(Dispatchers.IO) {
+            EpubWriter.save(context, displayName, title, paragraphs)
+        }
+    }
+
+    private fun buildEditedDisplayName(desiredName: String): String {
+        val trimmed = desiredName.trim().ifBlank { defaultEditedName() }
+        return if (trimmed.lowercase(Locale.US).endsWith(".epub")) trimmed else "$trimmed.epub"
+    }
+
+    private fun defaultEditedName(): String {
+        val base = _bookDisplayName.value?.substringBeforeLast('.')
+        return ((base?.takeIf { it.isNotBlank() }) ?: "edited_book") + "_edited.epub"
+    }
+
+    private fun combineUnitsToParagraphs(units: List<PlayableUnit>): List<String> {
+        if (units.isEmpty()) return emptyList()
+        val grouped = units.groupBy { it.paragraphIndex }.toSortedMap()
+        return grouped.values.map { unitGroup ->
+            unitGroup
+                .sortedBy { it.unitIndex }
+                .joinToString(" ") { it.text.trim() }
+                .replace(Regex("\\s+"), " ")
+                .trim()
+        }.flatMap { paragraph ->
+            paragraph
+                .split(Regex("\\n{2,}"))
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+        }
+    }
+
+    private fun resolveDisplayName(context: Context, uri: Uri): String {
+        context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val name = cursor.getString(0)
+                if (!name.isNullOrBlank()) return name
+            }
+        }
+        return uri.lastPathSegment ?: "document"
     }
 }

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -19,6 +19,7 @@ import com.example.nabu.utils.KokoroAudioPlayer
 import com.example.nabu.utils.PhonemeConverter
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PlaybackNotification
+import com.example.nabu.utils.StoragePermissions
 import com.example.nabu.utils.StyleLoader
 import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.playBook
@@ -163,6 +164,9 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     suspend fun saveEditedCopy(context: Context, desiredName: String): Uri? {
+        if (!StoragePermissions.hasRequiredPermissions(context)) {
+            throw SecurityException("Storage permission not granted")
+        }
         val units = _playableUnits.value
         if (units.isEmpty()) return null
         val displayName = buildEditedDisplayName(desiredName)


### PR DESCRIPTION
## Summary
- add an editor section to the book screen with editing mode, line updates, and an export workflow for modified books
- extend the book view model to track document metadata, accept text edits, and drive saving of edited EPUB copies
- introduce an EPUB writer utility that generates a minimal EPUB package for the edited content

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Gradle wrapper JAR missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ea97360f308331812204a7c79aeabe