### PR TITLE
Handle storage permissions when saving edited EPUBs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,13 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 <!--    <uses-permission android:name="android.permission.RECORD_AUDIO" />-->
-<!--    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"-->
-<!--        android:maxSdkVersion="32" />-->
-<!--    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"-->
-<!--        android:maxSdkVersion="32"-->
-<!--        tools:ignore="ScopedStorage" />-->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
 
     <application
         android:largeHeap="true"

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -96,6 +96,48 @@ fun BookScreen(
     var saveMessage by remember { mutableStateOf<String?>(null) }
     var saveSuccessful by remember { mutableStateOf(false) }
 
+    fun startSaveEditedCopy() {
+        if (isSavingEdited) return
+        isSavingEdited = true
+        saveMessage = null
+        saveSuccessful = false
+        scope.launch {
+            try {
+                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
+                if (uri != null) {
+                    saveMessage = "Saved edited copy"
+                    saveSuccessful = true
+                } else {
+                    saveMessage = "Unable to save edited copy"
+                    saveSuccessful = false
+                }
+            } catch (e: SecurityException) {
+                saveMessage = e.localizedMessage ?: "Storage permission is required to save edited copy"
+                saveSuccessful = false
+            } catch (e: Exception) {
+                saveMessage = e.localizedMessage ?: "Failed to save edited copy"
+                saveSuccessful = false
+            } finally {
+                isSavingEdited = false
+            }
+        }
+    }
+
+    var pendingSaveRequest by remember { mutableStateOf(false) }
+    val storagePermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) {
+        val hasPermissions = StoragePermissions.hasRequiredPermissions(context)
+        if (hasPermissions && pendingSaveRequest) {
+            pendingSaveRequest = false
+            startSaveEditedCopy()
+        } else if (!hasPermissions) {
+            pendingSaveRequest = false
+            saveMessage = "Storage permission is required to save edited copy"
+            saveSuccessful = false
+        }
+    }
+
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
@@ -140,6 +182,7 @@ fun BookScreen(
         saveMessage = null
         isSavingEdited = false
         saveSuccessful = false
+        pendingSaveRequest = false
     }
 
     LaunchedEffect(currentUnitIndex, followText) {
@@ -302,7 +345,7 @@ fun BookScreen(
 
         item {
             BrutalSection(
-                title = "Ebook Editor",
+                title = "Editor",
                 expanded = showEditorSection,
                 onToggle = { showEditorSection = !showEditorSection }
             ) {
@@ -367,25 +410,15 @@ fun BookScreen(
                 )
                 BrutalButton(
                     onClick = {
-                        isSavingEdited = true
-                        saveMessage = null
-                        saveSuccessful = false
-                        scope.launch {
-                            try {
-                                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
-                                if (uri != null) {
-                                    saveMessage = "Saved edited copy"
-                                    saveSuccessful = true
-                                } else {
-                                    saveMessage = "Unable to save edited copy"
-                                    saveSuccessful = false
-                                }
-                            } catch (e: Exception) {
-                                saveMessage = e.localizedMessage ?: "Failed to save edited copy"
-                                saveSuccessful = false
-                            } finally {
-                                isSavingEdited = false
-                            }
+                        if (isSavingEdited || lines.isEmpty()) {
+                            return@BrutalButton
+                        }
+                        val permissions = StoragePermissions.requiredPermissions()
+                        if (permissions.isEmpty() || StoragePermissions.hasRequiredPermissions(context)) {
+                            startSaveEditedCopy()
+                        } else {
+                            pendingSaveRequest = true
+                            storagePermissionLauncher.launch(permissions)
                         }
                     },
                     enabled = !isSavingEdited && lines.isNotEmpty(),

--- a/app/src/main/java/com/example/nabu/utils/StoragePermissions.kt
+++ b/app/src/main/java/com/example/nabu/utils/StoragePermissions.kt
@@ -1,0 +1,30 @@
+package com.example.nabu.utils
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+object StoragePermissions {
+    fun requiredPermissions(): Array<String> {
+        val permissions = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
+        }
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            permissions += Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        return permissions.toTypedArray()
+    }
+
+    fun hasRequiredPermissions(context: Context): Boolean {
+        val required = requiredPermissions()
+        if (required.isEmpty()) {
+            return true
+        }
+        return required.all { permission ->
+            ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+}

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -19,6 +19,7 @@ import com.example.nabu.utils.KokoroAudioPlayer
 import com.example.nabu.utils.PhonemeConverter
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PlaybackNotification
+import com.example.nabu.utils.StoragePermissions
 import com.example.nabu.utils.StyleLoader
 import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.playBook
@@ -163,6 +164,9 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
     }
 
     suspend fun saveEditedCopy(context: Context, desiredName: String): Uri? {
+        if (!StoragePermissions.hasRequiredPermissions(context)) {
+            throw SecurityException("Storage permission not granted")
+        }
         val units = _playableUnits.value
         if (units.isEmpty()) return null
         val displayName = buildEditedDisplayName(desiredName)


### PR DESCRIPTION
## Summary
- add explicit storage permissions to the manifest and centralize permission checks
- prompt users for legacy storage access before saving edited EPUB files to avoid silent failures
- rename the Ebook Editor section in the UI to “Editor”

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Gradle wrapper missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd09c8ab08331b1d11bbb4d67956b