### PR TITLE
Use SAF for saving edited EPUBs

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -99,9 +99,10 @@ fun BookScreen(
     var pendingSaveDisplayName by remember { mutableStateOf<String?>(null) }
 
     fun buildEditedDisplayName(name: String): String {
+        val currentBookDisplayName = bookDisplayName
         val trimmed = name.trim().ifBlank {
-            bookDisplayName
-                ?.substringBeforeLast('.', bookDisplayName)
+            currentBookDisplayName
+                ?.substringBeforeLast('.', currentBookDisplayName)
                 ?.takeIf { it.isNotBlank() }
                 ?.let { "${it}_edited" }
                 ?: "edited_book"

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -37,6 +37,7 @@ import com.mewmix.nabu.ui.brutalist.BrutalSlider
 import com.mewmix.nabu.ui.brutalist.SwitchToggle
 import androidx.compose.ui.unit.dp
 import com.example.nabu.ChatActivity
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
@@ -95,46 +96,48 @@ fun BookScreen(
     var isSavingEdited by remember { mutableStateOf(false) }
     var saveMessage by remember { mutableStateOf<String?>(null) }
     var saveSuccessful by remember { mutableStateOf(false) }
+    var pendingSaveDisplayName by remember { mutableStateOf<String?>(null) }
 
-    fun startSaveEditedCopy() {
-        if (isSavingEdited) return
-        isSavingEdited = true
-        saveMessage = null
-        saveSuccessful = false
+    fun buildEditedDisplayName(name: String): String {
+        val trimmed = name.trim().ifBlank {
+            bookDisplayName
+                ?.substringBeforeLast('.', bookDisplayName)
+                ?.takeIf { it.isNotBlank() }
+                ?.let { "${it}_edited" }
+                ?: "edited_book"
+        }
+        return if (trimmed.lowercase(Locale.US).endsWith(".epub")) trimmed else "$trimmed.epub"
+    }
+
+    val saveEditedDocumentLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument(EpubWriter.MIME_TYPE)
+    ) { uri: Uri? ->
+        val displayName = pendingSaveDisplayName
+        pendingSaveDisplayName = null
+        if (uri == null || displayName == null) {
+            if (uri == null && isSavingEdited) {
+                saveMessage = "Save canceled"
+                saveSuccessful = false
+            }
+            isSavingEdited = false
+            return@rememberLauncherForActivityResult
+        }
         scope.launch {
             try {
-                val uri = bookViewModel.saveEditedCopy(context, editedFileName)
-                if (uri != null) {
+                val saved = bookViewModel.saveEditedCopy(context, uri, displayName)
+                if (saved) {
                     saveMessage = "Saved edited copy"
                     saveSuccessful = true
                 } else {
                     saveMessage = "Unable to save edited copy"
                     saveSuccessful = false
                 }
-            } catch (e: SecurityException) {
-                saveMessage = e.localizedMessage ?: "Storage permission is required to save edited copy"
-                saveSuccessful = false
             } catch (e: Exception) {
                 saveMessage = e.localizedMessage ?: "Failed to save edited copy"
                 saveSuccessful = false
             } finally {
                 isSavingEdited = false
             }
-        }
-    }
-
-    var pendingSaveRequest by remember { mutableStateOf(false) }
-    val storagePermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestMultiplePermissions()
-    ) {
-        val hasPermissions = StoragePermissions.hasRequiredPermissions(context)
-        if (hasPermissions && pendingSaveRequest) {
-            pendingSaveRequest = false
-            startSaveEditedCopy()
-        } else if (!hasPermissions) {
-            pendingSaveRequest = false
-            saveMessage = "Storage permission is required to save edited copy"
-            saveSuccessful = false
         }
     }
 
@@ -182,7 +185,7 @@ fun BookScreen(
         saveMessage = null
         isSavingEdited = false
         saveSuccessful = false
-        pendingSaveRequest = false
+        pendingSaveDisplayName = null
     }
 
     LaunchedEffect(currentUnitIndex, followText) {
@@ -413,13 +416,13 @@ fun BookScreen(
                         if (isSavingEdited || lines.isEmpty()) {
                             return@BrutalButton
                         }
-                        val permissions = StoragePermissions.requiredPermissions()
-                        if (permissions.isEmpty() || StoragePermissions.hasRequiredPermissions(context)) {
-                            startSaveEditedCopy()
-                        } else {
-                            pendingSaveRequest = true
-                            storagePermissionLauncher.launch(permissions)
-                        }
+                        val displayName = buildEditedDisplayName(editedFileName)
+                        editedFileName = displayName
+                        isSavingEdited = true
+                        saveMessage = null
+                        saveSuccessful = false
+                        pendingSaveDisplayName = displayName
+                        saveEditedDocumentLauncher.launch(displayName)
                     },
                     enabled = !isSavingEdited && lines.isNotEmpty(),
                     modifier = Modifier.padding(top = dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
+++ b/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
@@ -1,10 +1,7 @@
 package com.example.nabu.utils
 
-import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
-import android.os.Environment
-import android.provider.MediaStore
 import java.io.BufferedOutputStream
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
@@ -14,29 +11,17 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 object EpubWriter {
-    private const val MIME_TYPE = "application/epub+zip"
+    const val MIME_TYPE = "application/epub+zip"
 
-    fun save(context: Context, displayName: String, title: String, paragraphs: List<String>): Uri? {
-        if (paragraphs.isEmpty()) return null
+    fun save(context: Context, uri: Uri, title: String, paragraphs: List<String>): Boolean {
+        if (paragraphs.isEmpty()) return false
         val resolver = context.contentResolver
-        val contentValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
-            put(MediaStore.MediaColumns.MIME_TYPE, MIME_TYPE)
-            put(
-                MediaStore.MediaColumns.RELATIVE_PATH,
-                Environment.DIRECTORY_DOCUMENTS + "/Nabu"
-            )
-        }
-        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, contentValues)
-            ?: return null
         return try {
-            resolver.openOutputStream(uri)?.use { outputStream ->
+            resolver.openOutputStream(uri, "wt")?.use { outputStream ->
                 writeEpub(outputStream, title.ifBlank { "Edited Book" }, paragraphs)
-            }
-            uri
+            } ?: false
         } catch (e: Exception) {
-            resolver.delete(uri, null, null)
-            null
+            false
         }
     }
 

--- a/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
+++ b/app/src/main/java/com/example/nabu/utils/EpubWriter.kt
@@ -19,6 +19,7 @@ object EpubWriter {
         return try {
             resolver.openOutputStream(uri, "wt")?.use { outputStream ->
                 writeEpub(outputStream, title.ifBlank { "Edited Book" }, paragraphs)
+                true
             } ?: false
         } catch (e: Exception) {
             false

--- a/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
+++ b/app/src/main/java/com/example/nabu/viewmodel/BookViewModel.kt
@@ -19,7 +19,6 @@ import com.example.nabu.utils.KokoroAudioPlayer
 import com.example.nabu.utils.PhonemeConverter
 import com.example.nabu.utils.PlayerState
 import com.example.nabu.utils.PlaybackNotification
-import com.example.nabu.utils.StoragePermissions
 import com.example.nabu.utils.StyleLoader
 import com.example.nabu.utils.TtsEngine
 import com.example.nabu.utils.playBook
@@ -163,17 +162,14 @@ class BookViewModel(private val app: Application) : AndroidViewModel(app) {
         _playableUnits.value = updated
     }
 
-    suspend fun saveEditedCopy(context: Context, desiredName: String): Uri? {
-        if (!StoragePermissions.hasRequiredPermissions(context)) {
-            throw SecurityException("Storage permission not granted")
-        }
+    suspend fun saveEditedCopy(context: Context, uri: Uri, desiredName: String): Boolean {
         val units = _playableUnits.value
-        if (units.isEmpty()) return null
+        if (units.isEmpty()) return false
         val displayName = buildEditedDisplayName(desiredName)
         val title = displayName.substringBeforeLast('.').ifBlank { "Edited Book" }
         val paragraphs = combineUnitsToParagraphs(units)
         return withContext(Dispatchers.IO) {
-            EpubWriter.save(context, displayName, title, paragraphs)
+            EpubWriter.save(context, uri, title, paragraphs)
         }
     }
 


### PR DESCRIPTION
## Summary
- let readers choose the destination for edited EPUB exports with the Storage Access Framework
- write EPUB data directly to the SAF provided Uri instead of relying on MediaStore paths
- remove legacy external storage permission handling from the editing flow

## Testing
- not run (Gradle wrapper JAR missing in repo)


------
https://chatgpt.com/codex/tasks/task_e_68ebd447231c8331878df41cbbaf40ab