### PR TITLE
Add immersive focus mode for reader

### DIFF
--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -982,6 +982,7 @@ private fun immersiveReaderLineVisuals(): ReaderLineVisuals {
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ReaderLine(
     line: String,

--- a/app/src/main/java/com/example/nabu/screens/BookScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/BookScreen.kt
@@ -11,22 +11,30 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.TextStyle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.nabu.R
 import com.example.nabu.utils.*
 import com.example.nabu.ui.components.ProgressDialog
 import com.example.nabu.ui.components.RadialWaveformVisualizer
+import com.example.nabu.ui.components.WaveformVisualizer
 import com.example.nabu.viewmodel.BookViewModel
 import kotlinx.coroutines.launch
 import com.mewmix.nabu.ui.brutalist.PanelBox
@@ -97,6 +105,7 @@ fun BookScreen(
     var saveMessage by remember { mutableStateOf<String?>(null) }
     var saveSuccessful by remember { mutableStateOf(false) }
     var pendingSaveDisplayName by remember { mutableStateOf<String?>(null) }
+    var isImmersiveReader by remember { mutableStateOf(false) }
 
     fun buildEditedDisplayName(name: String): String {
         val currentBookDisplayName = bookDisplayName
@@ -218,12 +227,67 @@ fun BookScreen(
         }
     }
 
-    PanelBox(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(dimensionResource(id = R.dimen.padding_large))
-    ) {
-        LazyColumn(
+    LaunchedEffect(lines) {
+        if (lines.isEmpty()) {
+            isImmersiveReader = false
+        }
+    }
+
+    fun startPlaybackFromLine(index: Int) {
+        bookViewModel.setCurrentUnitIndex(index)
+        bookViewModel.startPlayback(
+            session = session,
+            phonemeConverter = phonemeConverter,
+            styleLoader = styleLoader,
+            selectedStyles = selectedStyles,
+            weights = weights,
+            mode = interpolationMode,
+            speed = speed,
+            units = playableUnits,
+            startUnit = index,
+            bookUri = bookUri,
+            projectName = projectName,
+            context = context,
+            engine = SettingsManager.getTtsEngine(context),
+            usePregenerated = usePregenerated,
+            onFinished = {
+                bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
+                bookmark = null
+            },
+        )
+    }
+
+    fun handleLineClick(index: Int) {
+        if (isEditMode) {
+            editingLineIndex = index
+        } else if (selectedLines.contains(index)) {
+            selectedLines.remove(index)
+        } else {
+            startPlaybackFromLine(index)
+        }
+    }
+
+    fun handleLineLongPress(index: Int) {
+        if (selectedLines.contains(index)) {
+            selectedLines.remove(index)
+        } else {
+            selectedLines.add(index)
+        }
+    }
+
+    fun handleLineDoubleTap(index: Int) {
+        bookmark = Bookmark(index)
+        bookUri?.let { BookmarkManager.save(context, it.toString(), index) }
+    }
+
+    if (!isImmersiveReader) {
+        PanelBox(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(dimensionResource(id = R.dimen.padding_large))
+        ) {
+            val defaultLineVisuals = defaultReaderLineVisuals()
+            LazyColumn(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_medium)),
             state = listState
@@ -468,6 +532,12 @@ fun BookScreen(
             ) {
                 BrutalButton(onClick = { launcher.launch(arrayOf("text/plain", "application/epub+zip")) }) {
                     Text("OPEN")
+                }
+                BrutalButton(
+                    onClick = { isImmersiveReader = true },
+                    enabled = lines.isNotEmpty()
+                ) {
+                    Text("FOCUS")
                 }
                 val startPlaybackAction = {
                     if (playerState == PlayerState.PAUSED) {
@@ -719,65 +789,17 @@ fun BookScreen(
         }
 
         itemsIndexed(lines) { index, line ->
-            Text(
-                text = line,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .combinedClickable(
-                        onClick = {
-                            if (isEditMode) {
-                                editingLineIndex = index
-                            } else {
-                                if (selectedLines.contains(index)) {
-                                    selectedLines.remove(index)
-                                } else {
-                                    bookViewModel.setCurrentUnitIndex(index)
-                                    bookViewModel.startPlayback(
-                                        session = session,
-                                        phonemeConverter = phonemeConverter,
-                                        styleLoader = styleLoader,
-                                        selectedStyles = selectedStyles,
-                                        weights = weights,
-                                        mode = interpolationMode,
-                                        speed = speed,
-                                        units = playableUnits,
-                                        startUnit = index,
-                                        bookUri = bookUri,
-                                        projectName = projectName,
-                                        context = context,
-                                        engine = SettingsManager.getTtsEngine(context),
-                                        usePregenerated = usePregenerated,
-                                        onFinished = {
-                                            bookUri?.let { u -> BookmarkManager.clear(context, u.toString()) }
-                                            bookmark = null
-                                        },
-                                    )
-                                }
-                            }
-                        },
-                        onLongClick = {
-                            if (selectedLines.contains(index)) {
-                                selectedLines.remove(index)
-                            } else {
-                                selectedLines.add(index)
-                            }
-                        }
-                    )
-                    .background(
-                        when {
-                            selectedLines.contains(index) -> MaterialTheme.colorScheme.secondaryContainer
-                            index == currentUnitIndex -> MaterialTheme.colorScheme.primaryContainer
-                            else -> Color.Transparent
-                        }
-                    )
-                    .padding(dimensionResource(id = R.dimen.padding_small)),
-                color = when {
-                    selectedLines.contains(index) -> MaterialTheme.colorScheme.onSecondaryContainer
-                    index == currentUnitIndex -> MaterialTheme.colorScheme.onPrimaryContainer
-                    else -> MaterialTheme.colorScheme.onSurface
-                },
-                textAlign = TextAlign.Justify,
-                style = MaterialTheme.typography.bodyLarge
+            ReaderLine(
+                line = line,
+                isSelected = selectedLines.contains(index),
+                isCurrent = index == currentUnitIndex,
+                visuals = defaultLineVisuals,
+                modifier = Modifier.fillMaxWidth(),
+                textStyle = MaterialTheme.typography.bodyLarge,
+                contentPadding = PaddingValues(dimensionResource(id = R.dimen.padding_small)),
+                onClick = { handleLineClick(index) },
+                onLongClick = { handleLineLongPress(index) },
+                onDoubleTap = { handleLineDoubleTap(index) }
             )
         }
 
@@ -795,12 +817,211 @@ fun BookScreen(
     }
     }
 
+    }
+
+    if (isImmersiveReader) {
+        ImmersiveReaderOverlay(
+            lines = lines,
+            listState = listState,
+            currentUnitIndex = currentUnitIndex,
+            selectedLines = selectedLines,
+            playerState = playerState,
+            onDismiss = { isImmersiveReader = false },
+            onLineClick = ::handleLineClick,
+            onLineLongPress = ::handleLineLongPress,
+            onLineDoubleTap = ::handleLineDoubleTap
+        )
+    }
+
     if (isPregenerating) {
         ProgressDialog(
             message = "Pre-generating ${(preGenProgress * 100).toInt()}%",
             progress = preGenProgress
         )
     }
+}
+
+@Composable
+private fun ImmersiveReaderOverlay(
+    lines: List<String>,
+    listState: LazyListState,
+    currentUnitIndex: Int,
+    selectedLines: List<Int>,
+    playerState: PlayerState,
+    onDismiss: () -> Unit,
+    onLineClick: (Int) -> Unit,
+    onLineLongPress: (Int) -> Unit,
+    onLineDoubleTap: (Int) -> Unit,
+) {
+    val visuals = immersiveReaderLineVisuals()
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Brutal.panelBg.copy(alpha = 0.96f))
+    ) {
+        RadialWaveformVisualizer(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(48.dp),
+            lineColor = Brutal.green.copy(alpha = 0.4f),
+            visible = playerState != PlayerState.IDLE
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            Brutal.panelBg.copy(alpha = 0.94f),
+                            Brutal.panelBg.copy(alpha = 0.78f)
+                        )
+                    )
+                )
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 32.dp, vertical = 24.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                BrutalButton(onClick = onDismiss) {
+                    Text("EXIT")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            if (lines.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("Load a book to enter focus mode.", color = Brutal.textDim)
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    state = listState,
+                    verticalArrangement = Arrangement.spacedBy(18.dp)
+                ) {
+                    itemsIndexed(lines) { index, line ->
+                        ReaderLine(
+                            line = line,
+                            isSelected = selectedLines.contains(index),
+                            isCurrent = index == currentUnitIndex,
+                            visuals = visuals,
+                            modifier = Modifier.fillMaxWidth(),
+                            textStyle = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Start,
+                            contentPadding = PaddingValues(vertical = 14.dp, horizontal = 20.dp),
+                            shape = RoundedCornerShape(14.dp),
+                            onClick = { onLineClick(index) },
+                            onLongClick = { onLineLongPress(index) },
+                            onDoubleTap = { onLineDoubleTap(index) }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Brutal.panelHl.copy(alpha = 0.9f), RoundedCornerShape(16.dp))
+                    .padding(vertical = 18.dp, horizontal = 12.dp)
+            ) {
+                WaveformVisualizer(
+                    modifier = Modifier.fillMaxWidth(),
+                    visible = playerState != PlayerState.IDLE,
+                    lineColor = Brutal.green
+                )
+            }
+        }
+    }
+}
+
+private data class ReaderLineVisuals(
+    val selectedBackground: Color,
+    val currentBackground: Color,
+    val defaultBackground: Color,
+    val selectedText: Color,
+    val currentText: Color,
+    val defaultText: Color,
+)
+
+@Composable
+private fun defaultReaderLineVisuals(): ReaderLineVisuals {
+    val colorScheme = MaterialTheme.colorScheme
+    return ReaderLineVisuals(
+        selectedBackground = colorScheme.secondaryContainer,
+        currentBackground = colorScheme.primaryContainer,
+        defaultBackground = Color.Transparent,
+        selectedText = colorScheme.onSecondaryContainer,
+        currentText = colorScheme.onPrimaryContainer,
+        defaultText = colorScheme.onSurface
+    )
+}
+
+@Composable
+private fun immersiveReaderLineVisuals(): ReaderLineVisuals {
+    return ReaderLineVisuals(
+        selectedBackground = Brutal.panelHl.copy(alpha = 0.9f),
+        currentBackground = Brutal.panelHl.copy(alpha = 0.75f),
+        defaultBackground = Brutal.panelBg.copy(alpha = 0.6f),
+        selectedText = Brutal.green,
+        currentText = Brutal.textBright,
+        defaultText = Brutal.textDim
+    )
+}
+
+@Composable
+private fun ReaderLine(
+    line: String,
+    isSelected: Boolean,
+    isCurrent: Boolean,
+    visuals: ReaderLineVisuals,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle,
+    textAlign: TextAlign = TextAlign.Justify,
+    contentPadding: PaddingValues,
+    shape: Shape = RectangleShape,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    onDoubleTap: () -> Unit,
+) {
+    val background = when {
+        isSelected -> visuals.selectedBackground
+        isCurrent -> visuals.currentBackground
+        else -> visuals.defaultBackground
+    }
+    val textColor = when {
+        isSelected -> visuals.selectedText
+        isCurrent -> visuals.currentText
+        else -> visuals.defaultText
+    }
+
+    Text(
+        text = line,
+        modifier = modifier
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+                onDoubleClick = onDoubleTap
+            )
+            .background(background, shape)
+            .padding(contentPadding),
+        color = textColor,
+        textAlign = textAlign,
+        style = textStyle
+    )
 }
 
 private fun getDisplayName(context: android.content.Context, uri: Uri): String {


### PR DESCRIPTION
## Summary
- add an immersive reader focus mode overlay with a waveform backdrop and minimalist exit control
- expose a focus toggle from the reader controls and share a reusable ReaderLine renderer between standard and immersive layouts
- support double-tap bookmarking so line interactions remain available inside the focus canvas

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Gradle wrapper JAR is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebdf2dbb908331993cc72ca1375a76