### PR TITLE
Style app version badge and clarify model loading message

### DIFF
--- a/app/src/main/java/com/example/nabu/MainActivity.kt
+++ b/app/src/main/java/com/example/nabu/MainActivity.kt
@@ -81,6 +81,8 @@ import com.example.nabu.utils.saveAudio
 import com.example.nabu.utils.SettingsManager
 import com.example.nabu.utils.DebugLogger
 import com.example.nabu.utils.OnnxRuntimeManager
+import com.example.nabu.kokoro.Downloader
+import com.example.nabu.kokoro.RunEp
 import com.google.android.material.color.DynamicColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -90,6 +92,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.abs
+import java.util.Locale
 
 const val EXTRA_START_SCREEN = "start_screen"
 private const val PLAYBACK_CHANNEL_ID = "playback_channel"
@@ -497,9 +500,21 @@ fun BasicScreen(
     var expanded by remember { mutableStateOf(false) }
     var initTrigger by remember { mutableStateOf(0) }
     var modelState by remember { mutableStateOf<ModelState>(ModelState.Loading) }
+    var hasLocalModels by remember {
+        mutableStateOf(
+            Downloader.modelsAvailable(
+                context.applicationContext,
+                OnnxRuntimeManager.currentManifest()
+            )
+        )
+    }
 
     LaunchedEffect(initTrigger) {
         modelState = ModelState.Loading
+        hasLocalModels = Downloader.modelsAvailable(
+            context.applicationContext,
+            OnnxRuntimeManager.currentManifest()
+        )
         val result = withContext(Dispatchers.IO) {
             OnnxRuntimeManager.initialize(context.applicationContext)
         }
@@ -527,9 +542,16 @@ fun BasicScreen(
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             when (val state = modelState) {
                 ModelState.Loading -> {
+                    val runtimePreference = SettingsManager.getRuntimePreference(context)
+                    val runtimeLabel = runtimePreference.displayName()
+                    val loadingMessage = if (hasLocalModels) {
+                        "Loading $runtimeLabel runtime…"
+                    } else {
+                        "Downloading voice models…"
+                    }
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         CircularProgressIndicator(modifier = Modifier.padding(end = 8.dp))
-                        Text("Downloading voice models…")
+                        Text(loadingMessage, color = Brutal.textBright)
                     }
                 }
                 is ModelState.Error -> {
@@ -649,3 +671,6 @@ fun BasicScreen(
         }
     }
 }
+
+private fun RunEp.displayName(): String =
+    name.lowercase(Locale.ROOT).replaceFirstChar { it.titlecase(Locale.ROOT) }

--- a/app/src/main/java/com/example/nabu/components/VersionPlate.kt
+++ b/app/src/main/java/com/example/nabu/components/VersionPlate.kt
@@ -1,0 +1,45 @@
+package com.example.nabu.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
+import com.mewmix.nabu.ui.brutalist.Brutal
+import com.mewmix.nabu.ui.brutalist.LabelPlate
+
+private val VersionPlateShape: Shape = RoundedCornerShape(6.dp)
+
+@Composable
+fun VersionPlate(
+    version: String,
+    modifier: Modifier = Modifier,
+    label: String = "Version"
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .background(Brutal.panelHl, VersionPlateShape)
+            .border(1.dp, Brutal.hairline, VersionPlateShape)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        LabelPlate(text = label)
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = version,
+            color = Brutal.textBright,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/java/com/example/nabu/kokoro/Downloader.kt
+++ b/app/src/main/java/com/example/nabu/kokoro/Downloader.kt
@@ -62,6 +62,14 @@ object Downloader {
             }
         }
 
+    fun modelsAvailable(ctx: Context, manifest: Manifest): Boolean {
+        val root = File(ctx.filesDir, "")
+        return manifest.files.all { file ->
+            val outFile = File(root, file.dest)
+            outFile.exists()
+        }
+    }
+
     @Throws(IOException::class)
     private fun rangeDownload(url: String, target: File) {
         var existingBytes = if (target.exists()) target.length() else 0L

--- a/app/src/main/java/com/example/nabu/screens/CreditsConstellationScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/CreditsConstellationScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import com.mewmix.nabu.ui.brutalist.PanelBox
+import com.example.nabu.components.VersionPlate
 import com.example.nabu.utils.getAppVersion
 
 // Data classes representing credits hierarchy
@@ -163,10 +164,9 @@ fun CreditsConstellationScreen() {
                 }
             }
             Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = "Version $versionName",
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center
+            VersionPlate(
+                version = versionName,
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }

--- a/app/src/main/java/com/example/nabu/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/nabu/screens/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.nabu.kokoro.RunEp
+import com.example.nabu.components.VersionPlate
 import com.example.nabu.utils.SettingsManager
 import com.example.nabu.utils.OnnxRuntimeManager
 import com.example.nabu.utils.getAppVersion
@@ -101,10 +102,7 @@ fun SettingsScreen() {
                 }
             }
 
-            Text(
-                text = "Version $versionName",
-                style = MaterialTheme.typography.bodyMedium
-            )
+            VersionPlate(version = versionName)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable brutalist `VersionPlate` component and apply it to the Settings and Credits screens
- differentiate the voice model preparation copy so it references the selected runtime when assets are already local
- expose a simple downloader check to detect when Kokoro voice files are present

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68fc458147d88331ab8729ce91a82236