### PR TITLE
Refactor LLM architecture for multi-backend support

### DIFF
--- a/app-chat/src/main/java/com/mewmix/nabu/ChatViewModel.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/ChatViewModel.kt
@@ -12,7 +12,7 @@ import java.lang.StringBuilder
 
 data class ChatMessage(val message: String, val isFromUser: Boolean)
 
-class ChatViewModel(private val llmInference: LlmInference) : ViewModel() {
+class ChatViewModel(private val llmBackend: LlmBackend) : ViewModel() {
 
     private val _chatState = MutableStateFlow<List<ChatMessage>>(emptyList())
     val chatState: StateFlow<List<ChatMessage>> = _chatState.asStateFlow()
@@ -32,7 +32,7 @@ class ChatViewModel(private val llmInference: LlmInference) : ViewModel() {
 
         viewModelScope.launch(Dispatchers.IO) {
             val responseBuilder = StringBuilder()
-            llmInference.sendMessage(conversationHistory.toList()) { partialResult, done ->
+            llmBackend.sendMessage(conversationHistory.toList()) { partialResult, done ->
                 if (done) {
                     _isLoading.value = false
                     DebugLogger.log("ChatViewModel response complete")
@@ -57,6 +57,6 @@ class ChatViewModel(private val llmInference: LlmInference) : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
-        llmInference.close()
+        llmBackend.close()
     }
 }

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/LlamaCppBackend.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/LlamaCppBackend.kt
@@ -1,0 +1,51 @@
+package com.mewmix.nabu.chat
+
+import android.content.Context
+import com.mewmix.nabu.utils.DebugLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class LlamaCppBackend(
+    private val context: Context,
+    private val modelPath: String
+) : LlmBackend {
+
+    override fun initialize() {
+        DebugLogger.log("LlamaCppBackend initialize with model $modelPath (Stub)")
+    }
+
+    override fun sendMessage(
+        conversation: List<LlmMessage>,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    ) {
+        DebugLogger.log("LlamaCppBackend sendMessage (Stub)")
+        // Simulate streaming response
+        CoroutineScope(Dispatchers.IO).launch {
+            val response = "This is a stub response from Llama.cpp backend. Real inference coming soon!"
+            val chunks = response.split(" ")
+            chunks.forEachIndexed { index, chunk ->
+                delay(100)
+                resultListener("$chunk ", false)
+            }
+            resultListener("", true)
+        }
+    }
+
+    override fun sendMessage(
+        prompt: String,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    ) {
+        DebugLogger.log("LlamaCppBackend sendMessage prompt (Stub)")
+        CoroutineScope(Dispatchers.IO).launch {
+             val response = "This is a stub response from Llama.cpp backend (prompt mode)."
+             delay(500)
+             resultListener(response, true)
+        }
+    }
+
+    override fun close() {
+        DebugLogger.log("LlamaCppBackend close")
+    }
+}

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/LlmBackend.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/LlmBackend.kt
@@ -1,0 +1,17 @@
+package com.mewmix.nabu.chat
+
+interface LlmBackend {
+    fun initialize()
+
+    fun sendMessage(
+        conversation: List<LlmMessage>,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    )
+
+    fun sendMessage(
+        prompt: String,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    )
+
+    fun close()
+}

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/MediaPipeBackend.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/MediaPipeBackend.kt
@@ -5,16 +5,15 @@ import com.mewmix.nabu.utils.DebugLogger
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions
 
-
-class LlmInference(
+class MediaPipeBackend(
     private val context: Context,
     private val modelPath: String
-) {
+) : LlmBackend {
 
     private var llmInference: LlmInference? = null
 
-    fun initialize() {
-        DebugLogger.log("LlmInference initialize with model $modelPath")
+    override fun initialize() {
+        DebugLogger.log("MediaPipeBackend initialize with model $modelPath")
         val options = LlmInferenceOptions.builder()
             .setModelPath(modelPath)
             .build()
@@ -22,12 +21,12 @@ class LlmInference(
         llmInference = LlmInference.createFromOptions(context, options)
     }
 
-    fun sendMessage(
+    override fun sendMessage(
         conversation: List<LlmMessage>,
         resultListener: (partialResult: String, done: Boolean) -> Unit
     ) {
         if (conversation.isEmpty()) {
-            DebugLogger.log("LlmInference sendMessage received empty conversation; aborting request")
+            DebugLogger.log("MediaPipeBackend sendMessage received empty conversation; aborting request")
             return
         }
         if (llmInference == null) {
@@ -35,16 +34,16 @@ class LlmInference(
         }
 
         val payload = buildConversationPayload(conversation)
-        DebugLogger.log("LlmInference sendMessage with ${conversation.size} turns")
+        DebugLogger.log("MediaPipeBackend sendMessage with ${conversation.size} turns")
         llmInference?.generateResponseAsync(payload, resultListener)
     }
 
-    fun sendMessage(prompt: String, resultListener: (partialResult: String, done: Boolean) -> Unit) {
+    override fun sendMessage(prompt: String, resultListener: (partialResult: String, done: Boolean) -> Unit) {
         if (llmInference == null) {
             initialize()
         }
 
-        DebugLogger.log("LlmInference sendMessage: $prompt")
+        DebugLogger.log("MediaPipeBackend sendMessage: $prompt")
         llmInference?.generateResponseAsync(prompt, resultListener)
     }
 
@@ -57,7 +56,7 @@ class LlmInference(
         return sb.toString()
     }
 
-    fun close() {
+    override fun close() {
         llmInference?.close()
     }
 

--- a/app/src/main/java/com/mewmix/nabu/data/Model.kt
+++ b/app/src/main/java/com/mewmix/nabu/data/Model.kt
@@ -15,4 +15,5 @@ data class Model(
     val type: ModelType = ModelType.LLM,
     var isDownloaded: Boolean = false,
     var hasPartial: Boolean = false,
+    var backend: String = "mediapipe"
 )

--- a/app/src/main/java/com/mewmix/nabu/data/ModelManager.kt
+++ b/app/src/main/java/com/mewmix/nabu/data/ModelManager.kt
@@ -62,28 +62,44 @@ class ModelManager(private val context: Context) {
                 val partialDir = File(modelDir, "${model.id}_partial")
                 model.hasPartial = !model.isDownloaded && partialDir.exists()
             } else {
-                val modelFile = File(modelDir, "${model.id}.task")
-                val partialFile = File(modelDir, "${model.id}.task.part")
-                model.isDownloaded = modelFile.exists()
-                model.hasPartial = !model.isDownloaded && partialFile.exists()
+                val taskFile = File(modelDir, "${model.id}.task")
+                val ggufFile = File(modelDir, "${model.id}.gguf")
+
+                if (taskFile.exists()) {
+                    model.isDownloaded = true
+                    model.backend = "mediapipe"
+                } else if (ggufFile.exists()) {
+                    model.isDownloaded = true
+                    model.backend = "llama"
+                } else {
+                    model.isDownloaded = false
+                    val taskPart = File(modelDir, "${model.id}.task.part")
+                    val ggufPart = File(modelDir, "${model.id}.gguf.part")
+                    model.hasPartial = taskPart.exists() || ggufPart.exists()
+
+                    val jsonBackend = modelJson.optString("backend", "mediapipe")
+                    model.backend = jsonBackend
+                }
             }
             modelList.add(model)
         }
 
         // Include any additional models already placed in the models directory
         val modelDir = File(context.filesDir, "models")
-        modelDir.listFiles { _, name -> name.endsWith(".task") }?.forEach { file ->
+        modelDir.listFiles { _, name -> name.endsWith(".task") || name.endsWith(".gguf") }?.forEach { file ->
             val id = file.nameWithoutExtension
             if (modelList.none { it.id == id }) {
+                val backend = if (file.name.endsWith(".gguf")) "llama" else "mediapipe"
                 modelList.add(
                     Model(
                         id = id,
                         name = id,
-                        description = "Local model",
+                        description = "Local model ($backend)",
                         repo = "",
                         downloadUrl = "",
                         gated = false,
                         isDownloaded = true,
+                        backend = backend
                     )
                 )
             }
@@ -109,6 +125,8 @@ class ModelManager(private val context: Context) {
         } else {
             File(modelDir, "${model.id}.task").delete()
             File(modelDir, "${model.id}.task.part").delete()
+            File(modelDir, "${model.id}.gguf").delete()
+            File(modelDir, "${model.id}.gguf.part").delete()
         }
 
         if (model.repo.isEmpty() && model.downloadUrl.isEmpty()) {

--- a/app/src/main/java/com/mewmix/nabu/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/mewmix/nabu/viewmodel/ChatViewModel.kt
@@ -5,7 +5,9 @@ import android.os.SystemClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mewmix.nabu.chat.ChatMessage
-import com.mewmix.nabu.chat.LlmInference
+import com.mewmix.nabu.chat.LlmBackend
+import com.mewmix.nabu.chat.LlamaCppBackend
+import com.mewmix.nabu.chat.MediaPipeBackend
 import com.mewmix.nabu.chat.LlmMessage
 import com.mewmix.nabu.data.Conversation
 import com.mewmix.nabu.data.ConversationRepository
@@ -59,7 +61,7 @@ class ChatViewModel(
     }
 
     private val modelManager = ModelManager(context)
-    private var llmInference: LlmInference? = null
+    private var llmBackend: LlmBackend? = null
     private val conversationHistory = mutableListOf<ConversationTurn>()
 
     // Chat State
@@ -229,8 +231,8 @@ class ChatViewModel(
     fun sendMessage(message: String) {
         val trimmed = message.trim()
         if (trimmed.isEmpty()) return
-        val inference = llmInference ?: run {
-            DebugLogger.log("No LLM inference instance available; ignoring message")
+        val backend = llmBackend ?: run {
+            DebugLogger.log("No LLM backend available; ignoring message")
             return
         }
         val conversationId = _activeConversationId.value ?: run {
@@ -257,7 +259,7 @@ class ChatViewModel(
         val conversationForModel = prepareConversationForModel(DEFAULT_MAX_CONTEXT_TOKENS)
 
         viewModelScope.launch(Dispatchers.IO) {
-            inference.sendMessage(conversationForModel) { partial, done ->
+            backend.sendMessage(conversationForModel) { partial, done ->
                 if (benchmarkEnabled) {
                     if (!done) {
                         BenchmarkManager.recordPartial(partial)
@@ -393,21 +395,38 @@ class ChatViewModel(
     }
 
     private fun setActiveModel(model: Model, persistConversation: Boolean = true) {
-        if (_activeModel.value?.id == model.id && llmInference != null) {
+        if (_activeModel.value?.id == model.id && llmBackend != null) {
             _activeModel.value = model
             return
         }
         _activeModel.value = model
-        llmInference?.close()
-        val modelFile = File(context.filesDir, "models/${model.id}.task")
-        if (!modelFile.exists()) {
-            DebugLogger.log("Model file not found: ${modelFile.absolutePath}")
-            llmInference = null
-            return
+        llmBackend?.close()
+
+        val taskFile = File(context.filesDir, "models/${model.id}.task")
+        val ggufFile = File(context.filesDir, "models/${model.id}.gguf")
+
+        // Use backend set by ModelManager, or fallback to file existence check
+        val isLlama = model.backend == "llama" || (ggufFile.exists() && !taskFile.exists())
+
+        if (isLlama) {
+            if (!ggufFile.exists()) {
+                DebugLogger.log("GGUF Model file not found: ${ggufFile.absolutePath}")
+                llmBackend = null
+                return
+            }
+            val backend = LlamaCppBackend(context, ggufFile.absolutePath)
+            backend.initialize()
+            llmBackend = backend
+        } else {
+            if (!taskFile.exists()) {
+                DebugLogger.log("Task Model file not found: ${taskFile.absolutePath}")
+                llmBackend = null
+                return
+            }
+            val backend = MediaPipeBackend(context, taskFile.absolutePath)
+            backend.initialize()
+            llmBackend = backend
         }
-        val inference = LlmInference(context, modelFile.absolutePath)
-        inference.initialize()
-        llmInference = inference
         if (persistConversation) {
             val conversationId = _activeConversationId.value
             if (conversationId != null) {
@@ -659,7 +678,7 @@ class ChatViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        llmInference?.close()
+        llmBackend?.close()
         audioPlayer.stop()
     }
 }


### PR DESCRIPTION
* Introduced `LlmBackend` interface to abstract LLM implementation details.
* Refactored existing `LlmInference` wrapper to `MediaPipeBackend`.
* Created `LlamaCppBackend` stub for future integration with `llama.cpp` Android example.
* Updated `ModelManager` to detect GGUF models and automatically assign the `llama` backend.
* Updated `ChatViewModel` (app & app-chat) to utilize `LlmBackend` and select the appropriate implementation based on the model type.
* Renamed `LlmInference` class to `MediaPipeBackend` to avoid naming conflicts and clarify purpose.

---
*PR created automatically by Jules for task [10336749246304562364](https://jules.google.com/task/10336749246304562364) started by @mewmix*