### PR TITLE
Add ask-image API gating and LLM reply TTS support

### DIFF
--- a/app-chat/build.gradle.kts
+++ b/app-chat/build.gradle.kts
@@ -52,6 +52,7 @@ android {
 
 dependencies {
     implementation(project(":core-utils"))
+    implementation("com.google.mediapipe:tasks-core:latest.release")
     implementation("com.google.mediapipe:tasks-genai:0.10.24")
     implementation(platform("androidx.compose:compose-bom:2023.08.00"))
     implementation("androidx.compose.ui:ui")

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/LlamaCppBackend.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/LlamaCppBackend.kt
@@ -157,6 +157,16 @@ class LlamaCppBackend(
         }
     }
 
+    override fun supportsImageInput(): Boolean = false
+
+    override fun sendMessage(
+        conversation: List<LlmMessage>,
+        image: LlmImageInput,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    ) {
+        resultListener("Image input is not supported by llama.cpp backend.", true)
+    }
+
     private fun buildConversationPrompt(conversation: List<LlmMessage>): String {
         val sb = StringBuilder()
         conversation.forEach { message ->

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/LlmBackend.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/LlmBackend.kt
@@ -13,6 +13,16 @@ interface LlmBackend {
         resultListener: (partialResult: String, done: Boolean) -> Unit
     )
 
+    fun supportsImageInput(): Boolean = false
+
+    fun sendMessage(
+        conversation: List<LlmMessage>,
+        image: LlmImageInput,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    ) {
+        resultListener("Image input is not supported by this backend.", true)
+    }
+
     fun cancel()
 
     fun close()

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/LlmImageInput.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/LlmImageInput.kt
@@ -1,0 +1,7 @@
+package com.mewmix.nabu.chat
+
+import android.graphics.Bitmap
+
+data class LlmImageInput(
+    val bitmap: Bitmap
+)

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/MediaPipeBackend.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/MediaPipeBackend.kt
@@ -1,7 +1,9 @@
 package com.mewmix.nabu.chat
 
 import android.content.Context
+import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.mewmix.nabu.utils.DebugLogger
+import com.google.mediapipe.tasks.genai.llminference.GraphOptions
 import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession
 import com.google.mediapipe.tasks.genai.llminference.LlmInference
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions
@@ -70,6 +72,26 @@ class MediaPipeBackend(
         generateWithSession(payload, resultListener)
     }
 
+    override fun supportsImageInput(): Boolean = true
+
+    override fun sendMessage(
+        conversation: List<LlmMessage>,
+        image: LlmImageInput,
+        resultListener: (partialResult: String, done: Boolean) -> Unit
+    ) {
+        if (conversation.isEmpty()) {
+            DebugLogger.log("MediaPipeBackend image request received empty conversation; aborting request")
+            return
+        }
+        if (llmInference == null) {
+            initialize()
+        }
+
+        val payload = buildConversationPayload(conversation)
+        DebugLogger.log("MediaPipeBackend sendMessage(image) with ${conversation.size} turns")
+        generateWithSession(payload, resultListener, image)
+    }
+
     override fun sendMessage(prompt: String, resultListener: (partialResult: String, done: Boolean) -> Unit) {
         if (llmInference == null) {
             initialize()
@@ -100,7 +122,8 @@ class MediaPipeBackend(
 
     private fun generateWithSession(
         prompt: String,
-        resultListener: (partialResult: String, done: Boolean) -> Unit
+        resultListener: (partialResult: String, done: Boolean) -> Unit,
+        image: LlmImageInput? = null
     ) {
         val inference = llmInference ?: run {
             resultListener("MediaPipe backend unavailable.", true)
@@ -109,7 +132,7 @@ class MediaPipeBackend(
         try {
             val localConfig = config
             val boundedTopK = localConfig.topK.coerceIn(1, localConfig.maxTopK)
-            val sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
+            val optionsBuilder = LlmInferenceSession.LlmInferenceSessionOptions.builder()
                 .setTopK(boundedTopK)
                 .setTopP(localConfig.topP)
                 .setTemperature(localConfig.temperature)
@@ -118,12 +141,22 @@ class MediaPipeBackend(
                         setRandomSeed(localConfig.randomSeed)
                     }
                 }
-                .build()
+            if (image != null) {
+                optionsBuilder.setGraphOptions(
+                    GraphOptions.builder()
+                        .setEnableVisionModality(true)
+                        .build()
+                )
+            }
+            val sessionOptions = optionsBuilder.build()
 
             val session = LlmInferenceSession.createFromOptions(inference, sessionOptions)
             val previousSession = activeSession.getAndSet(session)
             previousSession?.cancelGenerateResponseAsync()
             previousSession?.close()
+            if (image != null) {
+                session.addImage(BitmapImageBuilder(image.bitmap).build())
+            }
             session.addQueryChunk(prompt)
             session.generateResponseAsync { partialResult, done ->
                 resultListener(partialResult.orEmpty(), done)

--- a/app-chat/src/main/java/com/mewmix/nabu/chat/VisionModelSupport.kt
+++ b/app-chat/src/main/java/com/mewmix/nabu/chat/VisionModelSupport.kt
@@ -1,0 +1,18 @@
+package com.mewmix.nabu.chat
+
+object VisionModelSupport {
+    // Keep this allowlist strict; only enable image input for model IDs verified in-app.
+    private val visionModelIds = setOf(
+        "gemma-3n-E4B-it-int4"
+    )
+
+    fun supportsImageInput(modelId: String): Boolean = modelId in visionModelIds
+
+    fun capabilitiesFor(modelId: String): Set<String> {
+        return if (supportsImageInput(modelId)) {
+            setOf("completion", "multimodal")
+        } else {
+            setOf("completion")
+        }
+    }
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,6 +33,10 @@
 -keep class com.google.gson.** { *; }
 -keepattributes Signature
 -keepattributes *Annotation*
+# Soprano tokenizer schema is parsed reflectively by Gson at runtime.
+# Keep nested model classes to prevent release obfuscation from turning
+# schema types into non-instantiable abstract references.
+-keep class com.mewmix.nabu.soprano.SopranoTokenizer$* { *; }
 
 # LiteRT / MediaPipe LLM rules (prevent proto field stripping)
 -keep class com.google.ai.edge.litert.** { *; }
@@ -46,3 +50,8 @@
 
 # Keep BuildConfig
 -keep class com.mewmix.nabu.BuildConfig { *; }
+
+# Ktor/SLF4J optional desktop-only hooks referenced by release shrinker
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
+-dontwarn org.slf4j.impl.StaticLoggerBinder

--- a/app/src/androidTest/java/com/mewmix/nabu/api/ApiServerInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mewmix/nabu/api/ApiServerInstrumentedTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStreamReader
 import java.net.Socket
 
@@ -34,6 +35,7 @@ class ApiServerInstrumentedTest {
         ApiServerManager.stop()
         SettingsManager.setApiEnabled(context, false)
         SettingsManager.setApiLanEnabled(context, false)
+        removeDummyTaskModel(NON_VISION_MODEL_ID)
     }
 
     @Test
@@ -47,12 +49,21 @@ class ApiServerInstrumentedTest {
         assertEquals(200, legacyModels.first)
         val legacyModelsJson = JSONObject(legacyModels.second)
         assertTrue(legacyModelsJson.has("models"))
+        val legacyData = legacyModelsJson.optJSONArray("models")
+        if (legacyData != null && legacyData.length() > 0) {
+            assertTrue(legacyData.getJSONObject(0).has("capabilities"))
+        }
 
         val models = rawHttpGet("/v1/models")
         assertEquals(200, models.first)
         val modelsJson = JSONObject(models.second)
         assertEquals("list", modelsJson.optString("object"))
         assertTrue(modelsJson.has("data"))
+        val v1Data = modelsJson.optJSONArray("data")
+        if (v1Data != null && v1Data.length() > 0) {
+            val metadata = v1Data.getJSONObject(0).optJSONObject("metadata")
+            assertTrue(metadata?.has("capabilities") == true)
+        }
 
         val ttsModels = rawHttpGet("/models?type=tts")
         assertEquals(200, ttsModels.first)
@@ -79,6 +90,132 @@ class ApiServerInstrumentedTest {
         assertEquals(400, postOpenAiTtsMissingInput.first)
         val postOpenAiTtsMissingInputJson = JSONObject(postOpenAiTtsMissingInput.second)
         assertTrue(postOpenAiTtsMissingInputJson.has("error"))
+    }
+
+    @Test
+    fun generateRejectsInvalidImageAndReplyTtsPayloads() {
+        val invalidImage = rawHttpPost(
+            "/generate",
+            """
+                {
+                  "prompt":"describe the image",
+                  "image_base64":"not-a-valid-base64"
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, invalidImage.first)
+        assertTrue(JSONObject(invalidImage.second).has("error"))
+
+        val invalidReplyTts = rawHttpPost(
+            "/generate",
+            """
+                {
+                  "prompt":"hello",
+                  "tts":{
+                    "enabled":true,
+                    "response_format":"wav"
+                  }
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, invalidReplyTts.first)
+        assertTrue(JSONObject(invalidReplyTts.second).has("error"))
+
+        val streamWithReplyTts = rawHttpPost(
+            "/generate",
+            """
+                {
+                  "prompt":"hello",
+                  "stream":true,
+                  "tts":true
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, streamWithReplyTts.first)
+        assertTrue(JSONObject(streamWithReplyTts.second).has("error"))
+
+        val unsupportedRemoteImage = rawHttpPost(
+            "/v1/chat/completions",
+            """
+                {
+                  "messages":[
+                    {
+                      "role":"user",
+                      "content":[
+                        {"type":"text","text":"what is this"},
+                        {"type":"image_url","image_url":{"url":"https://example.com/image.png"}}
+                      ]
+                    }
+                  ]
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, unsupportedRemoteImage.first)
+        assertTrue(JSONObject(unsupportedRemoteImage.second).has("error"))
+
+        val streamChatWithReplyTts = rawHttpPost(
+            "/v1/chat/completions",
+            """
+                {
+                  "stream":true,
+                  "tts":{"enabled":true},
+                  "messages":[
+                    {"role":"user","content":"hello"}
+                  ]
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, streamChatWithReplyTts.first)
+        assertTrue(JSONObject(streamChatWithReplyTts.second).has("error"))
+    }
+
+    @Test
+    fun generateImageRequestsAreGatedToVisionModels() {
+        installDummyTaskModel(NON_VISION_MODEL_ID)
+
+        val explicitUnsupportedModel = rawHttpPost(
+            "/generate",
+            """
+                {
+                  "model":"$NON_VISION_MODEL_ID",
+                  "prompt":"what is in this image?",
+                  "image_base64":"$ONE_PIXEL_IMAGE_BASE64"
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, explicitUnsupportedModel.first)
+        val explicitErrorMessage = JSONObject(explicitUnsupportedModel.second)
+            .optJSONObject("error")
+            ?.optString("message")
+            .orEmpty()
+        assertTrue(explicitErrorMessage.contains("does not support image input"))
+
+        val imageOnlyWithoutPrompt = rawHttpPost(
+            "/generate",
+            """
+                {
+                  "image_base64":"$ONE_PIXEL_IMAGE_BASE64"
+                }
+            """.trimIndent()
+        )
+        assertEquals(400, imageOnlyWithoutPrompt.first)
+        val imageOnlyErrorMessage = JSONObject(imageOnlyWithoutPrompt.second)
+            .optJSONObject("error")
+            ?.optString("message")
+            .orEmpty()
+        assertTrue(imageOnlyErrorMessage.contains("image-capable"))
+    }
+
+    private fun installDummyTaskModel(modelId: String) {
+        val modelDir = File(context.filesDir, "models")
+        if (!modelDir.exists()) {
+            modelDir.mkdirs()
+        }
+        File(modelDir, "$modelId.task").writeBytes(byteArrayOf(0x01.toByte()))
+    }
+
+    private fun removeDummyTaskModel(modelId: String) {
+        File(context.filesDir, "models/$modelId.task").delete()
     }
 
     private fun rawHttpGet(path: String): Pair<Int, String> {
@@ -148,5 +285,11 @@ class ApiServerInstrumentedTest {
             }
             return statusCode to body
         }
+    }
+
+    companion object {
+        private const val NON_VISION_MODEL_ID = "gemma3-1b-it-q4"
+        private const val ONE_PIXEL_IMAGE_BASE64 =
+            "Qk02AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA////AA=="
     }
 }

--- a/app/src/main/java/com/mewmix/nabu/MainActivity.kt
+++ b/app/src/main/java/com/mewmix/nabu/MainActivity.kt
@@ -94,6 +94,7 @@ import kotlinx.coroutines.withContext
 import kotlin.math.abs
 import java.util.Locale
 import com.mewmix.nabu.data.ModelManager
+import com.mewmix.nabu.data.TtsModelValidator
 import com.mewmix.nabu.data.ModelType
 import com.mewmix.nabu.screens.InitScreen
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -102,6 +103,7 @@ import com.mewmix.nabu.ui.components.GlobalStatusBar
 import com.mewmix.nabu.ui.components.RuntimeStatusLine
 import com.mewmix.nabu.data.ModelState
 import androidx.compose.runtime.collectAsState
+import java.io.File
 
 const val EXTRA_START_SCREEN = "start_screen"
 const val EXTRA_BOOK_URI = "book_uri"
@@ -235,8 +237,22 @@ private fun generateAudio(
         com.mewmix.nabu.utils.DebugLogger.log("Main.generateAudio: requesting engine")
         val engine = com.mewmix.nabu.tts.TTSManager.getEngine(context, modelManager)
         if (engine == null) {
+             val preferredEngine = SettingsManager.getTtsEngine(context)
+             val unavailableMessage = if (preferredEngine == "soprano") {
+                 val modelId = "soprano-80m-onnx"
+                 val modelDir = File(context.filesDir, "models/$modelId")
+                 val partialDir = File(context.filesDir, "models/${modelId}_partial")
+                 val missing = TtsModelValidator.missingFiles(modelId, modelDir, partialDir)
+                 if (missing.isEmpty()) {
+                     "Soprano model is not ready yet. Please retry download."
+                 } else {
+                     "Soprano download incomplete. Missing: ${missing.joinToString()}"
+                 }
+             } else {
+                 "No TTS engine available"
+             }
              withContext(Dispatchers.Main) {
-                Toast.makeText(context, "No TTS engine available", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, unavailableMessage, Toast.LENGTH_LONG).show()
                 onComplete()
             }
             return@launch

--- a/app/src/main/java/com/mewmix/nabu/api/ApiServer.kt
+++ b/app/src/main/java/com/mewmix/nabu/api/ApiServer.kt
@@ -1,10 +1,13 @@
 package com.mewmix.nabu.api
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import com.mewmix.nabu.chat.LlamaCppBackend
 import com.mewmix.nabu.chat.LlmBackend
+import com.mewmix.nabu.chat.LlmImageInput
 import com.mewmix.nabu.chat.LlmMessage
 import com.mewmix.nabu.chat.MediaPipeBackend
+import com.mewmix.nabu.chat.VisionModelSupport
 import com.mewmix.nabu.data.ModelManager
 import com.mewmix.nabu.data.ModelType
 import com.mewmix.nabu.kokoro.KokoroEngine
@@ -62,9 +65,11 @@ class ApiServer(
     private val styleLoader by lazy { StyleLoader(context) }
 
     companion object {
+        private const val DEFAULT_IMAGE_PROMPT = "Describe this image."
         private const val DEFAULT_TTS_VOICE = "af_sky"
         private val SUPPORTED_TTS_ENGINES = setOf("kokoro", "supertonic", "soprano")
         private val SUPPORTED_TTS_FORMATS = setOf("wav", "json")
+        private val SUPPORTED_LLM_REPLY_TTS_FORMATS = setOf("json")
     }
 
     fun start() {
@@ -155,9 +160,15 @@ class ApiServer(
         try {
             val body = JSONObject(call.receiveText())
             val requestedModel = body.optString("model").ifBlank { null }
-            val prompt = body.optString("prompt").trim()
+            var prompt = body.optString("prompt").trim()
             val messageArray = body.optJSONArray("messages")
             val stream = body.optBoolean("stream", false)
+            val replyTts = parseReplyTtsRequest(body)
+            val topLevelImage = parseTopLevelImageInput(body)
+
+            if (messageArray == null && topLevelImage != null && prompt.isEmpty()) {
+                prompt = DEFAULT_IMAGE_PROMPT
+            }
 
             if (prompt.isEmpty() && messageArray == null) {
                 respondApiError(
@@ -168,21 +179,50 @@ class ApiServer(
                 return
             }
 
+            if (stream && replyTts != null) {
+                respondApiError(
+                    call = call,
+                    status = HttpStatusCode.BadRequest,
+                    message = "'tts' is not supported when stream=true."
+                )
+                return
+            }
+
             if (stream) {
                 if (messageArray != null) {
+                    val parsedMessages = parseMessages(messageArray)
+                    if (topLevelImage != null) {
+                        throw IllegalArgumentException("Do not provide top-level image fields when 'messages' already include image content.")
+                    }
                     streamGenerateSse(
                         call = call,
                         requestedModel = requestedModel,
-                        sendGeneration = { backend, listener ->
-                            backend.sendMessage(parseMessages(messageArray), listener)
+                        requireImageInput = parsedMessages.image != null,
+                        sendGeneration = { modelId, backend, listener ->
+                            ensureImageInputSupported(modelId, backend, parsedMessages.image)
+                            if (parsedMessages.image != null) {
+                                backend.sendMessage(parsedMessages.messages, parsedMessages.image, listener)
+                            } else {
+                                backend.sendMessage(parsedMessages.messages, listener)
+                            }
                         }
                     )
                 } else {
                     streamGenerateSse(
                         call = call,
                         requestedModel = requestedModel,
-                        sendGeneration = { backend, listener ->
-                            backend.sendMessage(prompt, listener)
+                        requireImageInput = topLevelImage != null,
+                        sendGeneration = { modelId, backend, listener ->
+                            ensureImageInputSupported(modelId, backend, topLevelImage)
+                            if (topLevelImage != null) {
+                                backend.sendMessage(
+                                    listOf(LlmMessage(role = "user", content = prompt)),
+                                    topLevelImage,
+                                    listener
+                                )
+                            } else {
+                                backend.sendMessage(prompt, listener)
+                            }
                         }
                     )
                 }
@@ -190,14 +230,29 @@ class ApiServer(
             }
 
             val generation = if (messageArray != null) {
-                generateFromMessages(requestedModel, parseMessages(messageArray))
+                val parsedMessages = parseMessages(messageArray)
+                if (topLevelImage != null) {
+                    throw IllegalArgumentException("Do not provide top-level image fields when 'messages' already include image content.")
+                }
+                generateFromMessages(requestedModel, parsedMessages.messages, parsedMessages.image)
             } else {
-                generateFromPrompt(requestedModel, prompt)
+                generateFromPrompt(requestedModel, prompt, topLevelImage)
             }
 
             val response = JSONObject()
                 .put("model", generation.modelId)
                 .put("text", generation.text)
+            maybeSynthesizeReplyTts(replyTts, generation.text)?.let { tts ->
+                val wavBytes = toWavBytes(tts.audio, tts.sampleRate)
+                response.put(
+                    "audio",
+                    JSONObject()
+                        .put("engine", tts.engine)
+                        .put("model", tts.modelId)
+                        .put("sample_rate", tts.sampleRate)
+                        .put("audio_base64", Base64.getEncoder().encodeToString(wavBytes))
+                )
+            }
 
             call.respondText(
                 text = response.toString(),
@@ -233,6 +288,7 @@ class ApiServer(
                             .put("name", model.name)
                             .put("backend", modelBackend(model))
                             .put("type", model.type.name.lowercase())
+                            .put("capabilities", JSONArray(modelCapabilities(model).toList()))
                     )
                 }
             }
@@ -269,7 +325,8 @@ class ApiServer(
                             .put("owned_by", "local")
                             .put("metadata", JSONObject()
                                 .put("type", model.type.name.lowercase())
-                                .put("backend", modelBackend(model)))
+                                .put("backend", modelBackend(model))
+                                .put("capabilities", JSONArray(modelCapabilities(model).toList())))
                     )
                 }
             }
@@ -296,6 +353,7 @@ class ApiServer(
         try {
             val body = JSONObject(call.receiveText())
             val stream = body.optBoolean("stream", false)
+            val replyTts = parseReplyTtsRequest(body)
 
             val requestedModel = body.optString("model").ifBlank { null }
             val messageArray = body.optJSONArray("messages")
@@ -308,17 +366,25 @@ class ApiServer(
                 return
             }
 
-            val messages = parseMessages(messageArray)
+            val parsedMessages = parseMessages(messageArray)
+            if (stream && replyTts != null) {
+                respondApiError(
+                    call = call,
+                    status = HttpStatusCode.BadRequest,
+                    message = "'tts' is not supported when stream=true."
+                )
+                return
+            }
             if (stream) {
                 streamChatCompletionsSse(
                     call = call,
                     requestedModel = requestedModel,
-                    messages = messages
+                    payload = parsedMessages
                 )
                 return
             }
 
-            val generation = generateFromMessages(requestedModel, messages)
+            val generation = generateFromMessages(requestedModel, parsedMessages.messages, parsedMessages.image)
             val nowSeconds = System.currentTimeMillis() / 1000L
 
             val choice = JSONObject()
@@ -344,6 +410,17 @@ class ApiServer(
                         .put("completion_tokens", 0)
                         .put("total_tokens", 0)
                 )
+            maybeSynthesizeReplyTts(replyTts, generation.text)?.let { tts ->
+                val wavBytes = toWavBytes(tts.audio, tts.sampleRate)
+                response.put(
+                    "audio",
+                    JSONObject()
+                        .put("engine", tts.engine)
+                        .put("model", tts.modelId)
+                        .put("sample_rate", tts.sampleRate)
+                        .put("audio_base64", Base64.getEncoder().encodeToString(wavBytes))
+                )
+            }
 
             call.respondText(
                 text = response.toString(),
@@ -368,7 +445,8 @@ class ApiServer(
     private suspend fun streamGenerateSse(
         call: io.ktor.server.application.ApplicationCall,
         requestedModel: String?,
-        sendGeneration: (LlmBackend, (String, Boolean) -> Unit) -> Unit
+        requireImageInput: Boolean = false,
+        sendGeneration: (String, LlmBackend, (String, Boolean) -> Unit) -> Unit
     ) {
         call.respondTextWriter(
             contentType = ContentType.Text.EventStream,
@@ -378,14 +456,14 @@ class ApiServer(
             val created = System.currentTimeMillis() / 1000L
             try {
                 requestLock.withLock {
-                    val (modelId, activeBackend) = getOrCreateBackend(requestedModel)
+                    val (modelId, activeBackend) = getOrCreateBackend(requestedModel, requireImageInput)
                     when (activeBackend) {
                         is LlamaCppBackend -> activeBackend.updateConfig(SettingsManager.getLlmRuntimeConfig(context))
                         is MediaPipeBackend -> activeBackend.updateConfig(SettingsManager.getMediaPipeRuntimeConfig(context))
                     }
 
                     val stream = Channel<StreamEvent>(Channel.UNLIMITED)
-                    sendGeneration(activeBackend) { partial, done ->
+                    sendGeneration(modelId, activeBackend) { partial, done ->
                         if (partial.isNotEmpty()) {
                             stream.trySend(StreamEvent.Token(partial))
                         }
@@ -443,7 +521,7 @@ class ApiServer(
     private suspend fun streamChatCompletionsSse(
         call: io.ktor.server.application.ApplicationCall,
         requestedModel: String?,
-        messages: List<LlmMessage>
+        payload: ParsedMessages
     ) {
         call.respondTextWriter(
             contentType = ContentType.Text.EventStream,
@@ -453,21 +531,35 @@ class ApiServer(
             val created = System.currentTimeMillis() / 1000L
             try {
                 requestLock.withLock {
-                    val (modelId, activeBackend) = getOrCreateBackend(requestedModel)
+                    val (modelId, activeBackend) = getOrCreateBackend(requestedModel, payload.image != null)
                     when (activeBackend) {
                         is LlamaCppBackend -> activeBackend.updateConfig(SettingsManager.getLlmRuntimeConfig(context))
                         is MediaPipeBackend -> activeBackend.updateConfig(SettingsManager.getMediaPipeRuntimeConfig(context))
                     }
 
                     val stream = Channel<StreamEvent>(Channel.UNLIMITED)
-                    activeBackend.sendMessage(messages) { partial, done ->
-                        if (partial.isNotEmpty()) {
-                            stream.trySend(StreamEvent.Token(partial))
+                    ensureImageInputSupported(modelId, activeBackend, payload.image)
+                    if (payload.image != null) {
+                        activeBackend.sendMessage(payload.messages, payload.image) { partial, done ->
+                            if (partial.isNotEmpty()) {
+                                stream.trySend(StreamEvent.Token(partial))
+                            }
+                            if (done) {
+                                stream.trySend(StreamEvent.Done)
+                                stream.close()
+                                return@sendMessage
+                            }
                         }
-                        if (done) {
-                            stream.trySend(StreamEvent.Done)
-                            stream.close()
-                            return@sendMessage
+                    } else {
+                        activeBackend.sendMessage(payload.messages) { partial, done ->
+                            if (partial.isNotEmpty()) {
+                                stream.trySend(StreamEvent.Token(partial))
+                            }
+                            if (done) {
+                                stream.trySend(StreamEvent.Done)
+                                stream.close()
+                                return@sendMessage
+                            }
                         }
                     }
 
@@ -674,41 +766,64 @@ class ApiServer(
         )
     }
 
-    private suspend fun generateFromPrompt(requestedModel: String?, prompt: String): GenerationResult {
-        return requestLock.withLock {
-            val (modelId, activeBackend) = getOrCreateBackend(requestedModel)
-            if (activeBackend is LlamaCppBackend) {
-                activeBackend.updateConfig(SettingsManager.getLlmRuntimeConfig(context))
-            } else if (activeBackend is MediaPipeBackend) {
-                activeBackend.updateConfig(SettingsManager.getMediaPipeRuntimeConfig(context))
+    private suspend fun generateFromPrompt(
+        requestedModel: String?,
+        prompt: String,
+        image: LlmImageInput? = null
+    ): GenerationResult {
+        if (image == null) {
+            return requestLock.withLock {
+                val (modelId, activeBackend) = getOrCreateBackend(requestedModel, false)
+                if (activeBackend is LlamaCppBackend) {
+                    activeBackend.updateConfig(SettingsManager.getLlmRuntimeConfig(context))
+                } else if (activeBackend is MediaPipeBackend) {
+                    activeBackend.updateConfig(SettingsManager.getMediaPipeRuntimeConfig(context))
+                }
+                val text = runGeneration { listener ->
+                    activeBackend.sendMessage(prompt, listener)
+                }
+                GenerationResult(modelId = modelId, text = text)
             }
-            val text = runGeneration { listener ->
-                activeBackend.sendMessage(prompt, listener)
-            }
-            GenerationResult(modelId = modelId, text = text)
         }
+        return generateFromMessages(
+            requestedModel = requestedModel,
+            messages = listOf(LlmMessage(role = "user", content = prompt)),
+            image = image
+        )
     }
 
-    private suspend fun generateFromMessages(requestedModel: String?, messages: List<LlmMessage>): GenerationResult {
+    private suspend fun generateFromMessages(
+        requestedModel: String?,
+        messages: List<LlmMessage>,
+        image: LlmImageInput? = null
+    ): GenerationResult {
         if (messages.isEmpty()) {
             throw IllegalArgumentException("'messages' cannot be empty")
         }
 
         return requestLock.withLock {
-            val (modelId, activeBackend) = getOrCreateBackend(requestedModel)
+            val (modelId, activeBackend) = getOrCreateBackend(requestedModel, image != null)
             if (activeBackend is LlamaCppBackend) {
                 activeBackend.updateConfig(SettingsManager.getLlmRuntimeConfig(context))
             } else if (activeBackend is MediaPipeBackend) {
                 activeBackend.updateConfig(SettingsManager.getMediaPipeRuntimeConfig(context))
             }
+            ensureImageInputSupported(modelId, activeBackend, image)
             val text = runGeneration { listener ->
-                activeBackend.sendMessage(messages, listener)
+                if (image != null) {
+                    activeBackend.sendMessage(messages, image, listener)
+                } else {
+                    activeBackend.sendMessage(messages, listener)
+                }
             }
             GenerationResult(modelId = modelId, text = text)
         }
     }
 
-    private fun getOrCreateBackend(requestedModelId: String?): Pair<String, LlmBackend> {
+    private fun getOrCreateBackend(
+        requestedModelId: String?,
+        requireImageInput: Boolean = false
+    ): Pair<String, LlmBackend> {
         synchronized(backendLock) {
             val availableModels = listAvailableModels(ModelScope.LLM)
             if (availableModels.isEmpty()) {
@@ -716,10 +831,23 @@ class ApiServer(
             }
 
             val targetModel = if (requestedModelId.isNullOrBlank()) {
-                availableModels.first()
+                if (requireImageInput) {
+                    availableModels.firstOrNull { modelSupportsImageInput(it) }
+                        ?: throw IllegalArgumentException(
+                            "No downloaded image-capable model available. Download an allowlisted multimodal model and retry."
+                        )
+                } else {
+                    availableModels.first()
+                }
             } else {
-                availableModels.firstOrNull { it.id == requestedModelId }
+                val requested = availableModels.firstOrNull { it.id == requestedModelId }
                     ?: throw IllegalArgumentException("Requested model is not available: $requestedModelId")
+                if (requireImageInput && !modelSupportsImageInput(requested)) {
+                    throw IllegalArgumentException(
+                        "Requested model '$requestedModelId' does not support image input."
+                    )
+                }
+                requested
             }
 
             if (backend != null && backendModelId == targetModel.id) {
@@ -763,6 +891,15 @@ class ApiServer(
         }
     }
 
+    private fun modelSupportsImageInput(model: com.mewmix.nabu.data.Model): Boolean {
+        if (!VisionModelSupport.supportsImageInput(model.id)) return false
+
+        val taskFile = File(context.filesDir, "models/${model.id}.task")
+        val ggufFile = File(context.filesDir, "models/${model.id}.gguf")
+        val isLlama = model.backend == "llama" || (ggufFile.exists() && !taskFile.exists())
+        return !isLlama
+    }
+
     private suspend fun runGeneration(
         send: (resultListener: (partialResult: String, done: Boolean) -> Unit) -> Unit
     ): String {
@@ -791,21 +928,145 @@ class ApiServer(
         }
     }
 
-    private fun parseMessages(input: JSONArray): List<LlmMessage> {
+    private fun parseMessages(input: JSONArray): ParsedMessages {
         val messages = mutableListOf<LlmMessage>()
+        var image: LlmImageInput? = null
+
         for (i in 0 until input.length()) {
             val item = input.optJSONObject(i) ?: continue
             val rawRole = item.optString("role").trim()
-            val content = item.optString("content").trim()
-            if (rawRole.isEmpty() || content.isEmpty()) continue
-
+            if (rawRole.isEmpty()) continue
             val role = when (rawRole.lowercase()) {
                 "assistant" -> "model"
                 else -> rawRole.lowercase()
             }
-            messages.add(LlmMessage(role = role, content = content))
+
+            val parsed = parseMessageContent(item, role)
+            if (parsed.content.isNotEmpty()) {
+                messages.add(LlmMessage(role = role, content = parsed.content))
+            }
+            if (parsed.image != null) {
+                if (image != null) {
+                    throw IllegalArgumentException("Only one image input is supported per request.")
+                }
+                image = parsed.image
+            }
         }
-        return messages
+
+        if (messages.isEmpty()) {
+            throw IllegalArgumentException("'messages' must include at least one non-empty content entry.")
+        }
+        return ParsedMessages(messages = messages, image = image)
+    }
+
+    private fun parseMessageContent(item: JSONObject, role: String): ParsedMessageContent {
+        val contentRaw = item.opt("content")
+        if (contentRaw is JSONArray) {
+            val textParts = mutableListOf<String>()
+            var image: LlmImageInput? = null
+            for (idx in 0 until contentRaw.length()) {
+                val part = contentRaw.optJSONObject(idx) ?: continue
+                when (part.optString("type").trim().lowercase()) {
+                    "text" -> {
+                        val text = part.optString("text").trim()
+                        if (text.isNotEmpty()) {
+                            textParts.add(text)
+                        }
+                    }
+                    "image_url" -> {
+                        if (role != "user") {
+                            throw IllegalArgumentException("Image input is only supported for user messages.")
+                        }
+                        if (image != null) {
+                            throw IllegalArgumentException("Only one image input is supported per request.")
+                        }
+                        val imageUrl = part.optJSONObject("image_url")
+                            ?.optString("url")
+                            ?.trim()
+                            ?.ifBlank { null }
+                            ?: part.optString("image_url").trim().ifBlank { null }
+                            ?: throw IllegalArgumentException("'image_url' entry is missing a usable 'url' value.")
+                        image = decodeImageInput(imageUrl)
+                    }
+                    else -> Unit
+                }
+            }
+            var content = textParts.joinToString("\n").trim()
+            if (image != null && content.isEmpty()) {
+                content = DEFAULT_IMAGE_PROMPT
+            }
+            return ParsedMessageContent(content = content, image = image)
+        }
+
+        return ParsedMessageContent(
+            content = item.optString("content").trim(),
+            image = null
+        )
+    }
+
+    private fun parseTopLevelImageInput(body: JSONObject): LlmImageInput? {
+        val imageBase64 = body.optString("image_base64").trim().ifBlank { null }
+        val imageUrl = when (val raw = body.opt("image_url")) {
+            is JSONObject -> raw.optString("url").trim().ifBlank { null }
+            is String -> raw.trim().ifBlank { null }
+            else -> null
+        }
+        val imageData = body.optString("image").trim().ifBlank { null }
+
+        val provided = listOfNotNull(imageBase64, imageUrl, imageData)
+        if (provided.isEmpty()) return null
+        if (provided.size > 1) {
+            throw IllegalArgumentException("Provide only one of: image_base64, image_url, image.")
+        }
+        return decodeImageInput(provided.first())
+    }
+
+    private fun decodeImageInput(raw: String): LlmImageInput {
+        val value = raw.trim()
+        if (value.isEmpty()) {
+            throw IllegalArgumentException("Image payload is empty.")
+        }
+        if (value.startsWith("http://", ignoreCase = true) || value.startsWith("https://", ignoreCase = true)) {
+            throw IllegalArgumentException("Remote image URLs are not supported. Provide a data URL or base64 image payload.")
+        }
+
+        val base64Payload = if (value.startsWith("data:", ignoreCase = true)) {
+            val commaIndex = value.indexOf(',')
+            if (commaIndex <= 0 || commaIndex >= value.length - 1) {
+                throw IllegalArgumentException("Invalid data URL image payload.")
+            }
+            val meta = value.substring(0, commaIndex)
+            if (!meta.contains(";base64", ignoreCase = true)) {
+                throw IllegalArgumentException("Only base64 data URL images are supported.")
+            }
+            value.substring(commaIndex + 1)
+        } else {
+            value
+        }
+
+        val imageBytes = try {
+            Base64.getDecoder().decode(base64Payload)
+        } catch (_: IllegalArgumentException) {
+            throw IllegalArgumentException("Image payload is not valid base64.")
+        }
+
+        val bitmap = BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+            ?: throw IllegalArgumentException("Unable to decode image payload.")
+        return LlmImageInput(bitmap = bitmap)
+    }
+
+    private fun ensureImageInputSupported(modelId: String, backend: LlmBackend, image: LlmImageInput?) {
+        if (image == null) return
+        if (!VisionModelSupport.supportsImageInput(modelId)) {
+            throw IllegalArgumentException(
+                "Model '$modelId' is not allowlisted for image input."
+            )
+        }
+        if (!backend.supportsImageInput()) {
+            throw IllegalArgumentException(
+                "Backend for model '$modelId' does not support image input."
+            )
+        }
     }
 
     private suspend fun Writer.writeSseData(payload: String) {
@@ -907,6 +1168,85 @@ class ApiServer(
                 }
             }
         }
+    }
+
+    private fun parseReplyTtsRequest(body: JSONObject): ReplyTtsRequest? {
+        if (!body.has("tts")) return null
+        val raw = body.opt("tts")
+        if (raw == null || raw == JSONObject.NULL) return null
+
+        if (raw is Boolean) {
+            if (!raw) return null
+            return ReplyTtsRequest(
+                speed = 1.0f,
+                voice = null,
+                target = resolveTtsTarget(
+                    requestedEngine = null,
+                    requestedModel = null,
+                    requestedSupertonicModel = null
+                ),
+                responseFormat = "json"
+            )
+        }
+
+        val ttsBody = raw as? JSONObject
+            ?: throw IllegalArgumentException("'tts' must be a boolean or an object.")
+        val enabled = if (ttsBody.has("enabled")) ttsBody.optBoolean("enabled", true) else true
+        if (!enabled) return null
+
+        val speed = ttsBody.optDouble("speed", 1.0).toFloat()
+        if (!speed.isFinite() || speed <= 0f) {
+            throw IllegalArgumentException("'tts.speed' must be a positive number.")
+        }
+
+        val responseFormat = ttsBody.optString("response_format")
+            .trim()
+            .lowercase()
+            .ifBlank { "json" }
+        if (responseFormat !in SUPPORTED_LLM_REPLY_TTS_FORMATS) {
+            throw IllegalArgumentException(
+                "Unsupported 'tts.response_format' '$responseFormat'. Use one of: ${SUPPORTED_LLM_REPLY_TTS_FORMATS.joinToString()}."
+            )
+        }
+
+        val voice = ttsBody.optString("voice")
+            .ifBlank { ttsBody.optString("style") }
+            .trim()
+            .ifBlank { null }
+
+        val requestedEngine = ttsBody.optString("engine").trim().lowercase().ifBlank { null }
+        val requestedModel = ttsBody.optString("model").trim().ifBlank { null }
+        val requestedSupertonicModel = ttsBody.optString("supertonic_model").trim().ifBlank { null }
+        val target = resolveTtsTarget(
+            requestedEngine = requestedEngine,
+            requestedModel = requestedModel,
+            requestedSupertonicModel = requestedSupertonicModel
+        )
+
+        return ReplyTtsRequest(
+            speed = speed,
+            voice = voice,
+            target = target,
+            responseFormat = responseFormat
+        )
+    }
+
+    private suspend fun maybeSynthesizeReplyTts(request: ReplyTtsRequest?, text: String): TtsSynthesisResult? {
+        if (request == null) return null
+        if (request.responseFormat != "json") {
+            throw IllegalArgumentException("Only 'json' TTS response format is supported for LLM replies.")
+        }
+        val normalizedText = text.trim()
+        if (normalizedText.isEmpty()) return null
+
+        return synthesizeTts(
+            TtsSynthesisRequest(
+                input = normalizedText,
+                speed = request.speed,
+                voice = request.voice,
+                target = request.target
+            )
+        )
     }
 
     private fun unwrapTtsEngine(engine: TTSEngine): TTSEngine =
@@ -1067,6 +1407,14 @@ class ApiServer(
         }
     }
 
+    private fun modelCapabilities(model: com.mewmix.nabu.data.Model): Set<String> {
+        return if (model.type == ModelType.TTS) {
+            setOf("tts")
+        } else {
+            VisionModelSupport.capabilitiesFor(model.id)
+        }
+    }
+
     private suspend fun parseModelScope(
         call: io.ktor.server.application.ApplicationCall,
         default: ModelScope
@@ -1128,6 +1476,16 @@ class ApiServer(
         val text: String
     )
 
+    private data class ParsedMessages(
+        val messages: List<LlmMessage>,
+        val image: LlmImageInput?
+    )
+
+    private data class ParsedMessageContent(
+        val content: String,
+        val image: LlmImageInput?
+    )
+
     private data class TtsRequestTarget(
         val engine: String,
         val supertonicModelId: String?
@@ -1145,6 +1503,13 @@ class ApiServer(
         val sampleRate: Int,
         val modelId: String,
         val engine: String
+    )
+
+    private data class ReplyTtsRequest(
+        val speed: Float,
+        val voice: String?,
+        val target: TtsRequestTarget,
+        val responseFormat: String
     )
 
     private sealed interface StreamEvent {

--- a/app/src/main/java/com/mewmix/nabu/data/ModelDownloader.kt
+++ b/app/src/main/java/com/mewmix/nabu/data/ModelDownloader.kt
@@ -4,6 +4,7 @@ import com.mewmix.nabu.kokoro.Downloader
 import com.mewmix.nabu.utils.DebugLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
@@ -14,6 +15,10 @@ class ModelDownloader(
     private val context: android.content.Context,
     private val userPreferencesRepository: UserPreferencesRepository,
 ) {
+    companion object {
+        private val activeModelDownloads = mutableSetOf<String>()
+    }
+
     data class DetailedProgress(
         val currentFile: String,
         val downloadedBytes: Long,
@@ -34,11 +39,24 @@ class ModelDownloader(
     val detailedProgress: StateFlow<Map<String, DetailedProgress>> = _detailedProgress
 
     fun downloadModel(model: Model) {
+        val acquired = synchronized(activeModelDownloads) {
+            activeModelDownloads.add(model.id)
+        }
+        if (!acquired) {
+            DebugLogger.log("ModelDownloader: Download already in progress for ${model.id}, skipping duplicate request")
+            return
+        }
         scope.launch {
-            if (model.type == ModelType.TTS) {
-                downloadTtsModel(model)
-            } else {
-                downloadLlmModel(model)
+            try {
+                if (model.type == ModelType.TTS) {
+                    downloadTtsModel(model)
+                } else {
+                    downloadLlmModel(model)
+                }
+            } finally {
+                synchronized(activeModelDownloads) {
+                    activeModelDownloads.remove(model.id)
+                }
             }
         }
     }
@@ -54,7 +72,7 @@ class ModelDownloader(
         val headers = authHeaders(token)
         val baseUrl = ttsBaseUrl(model)
 
-        val allPresent = hasAllFiles(targetDir, fileSpecs)
+        val allPresent = hasAllFiles(model.id, targetDir, fileSpecs)
         if (allPresent) {
             model.isDownloaded = true
             model.hasPartial = false
@@ -62,23 +80,30 @@ class ModelDownloader(
             return
         }
 
-        val missingSpecs = if (targetDir.exists()) {
-            fileSpecs.filter { !File(targetDir, it.localPath).exists() }
-        } else {
-            fileSpecs
+        val destinationRoot = when {
+            targetDir.exists() -> targetDir
+            partialDir.exists() -> partialDir
+            else -> {
+                partialDir.mkdirs()
+                partialDir
+            }
+        }
+        val missingSpecs = fileSpecs.filter { spec ->
+            !TtsModelValidator.isFileValid(model.id, spec.localPath, File(destinationRoot, spec.localPath))
         }
 
         if (missingSpecs.isEmpty()) {
-            model.isDownloaded = true
+            // If all files are valid in partial dir, promote it to final destination.
+            if (destinationRoot == partialDir) {
+                if (targetDir.exists()) targetDir.deleteRecursively()
+                if (!partialDir.renameTo(targetDir)) {
+                    partialDir.copyRecursively(targetDir, overwrite = true)
+                    partialDir.deleteRecursively()
+                }
+            }
+            model.isDownloaded = hasAllFiles(model.id, targetDir, fileSpecs)
             model.hasPartial = false
             return
-        }
-
-        val destinationRoot = if (targetDir.exists()) {
-            targetDir
-        } else {
-            if (!partialDir.exists()) partialDir.mkdirs()
-            partialDir
         }
 
         model.hasPartial = true
@@ -89,8 +114,19 @@ class ModelDownloader(
             missingSpecs.forEachIndexed { index, spec ->
                 val fileUrl = buildFileUrl(baseUrl, spec.remotePath)
                 val destFile = File(destinationRoot, spec.localPath)
+                val partFile = File(destinationRoot, "${spec.localPath}.part")
                 val displayName = spec.localPath.substringAfterLast('/')
                 val baseFraction = index.toFloat() / totalFiles.toFloat()
+
+                destFile.parentFile?.mkdirs()
+                partFile.parentFile?.mkdirs()
+                if (destFile.exists() && !TtsModelValidator.isFileValid(model.id, spec.localPath, destFile)) {
+                    destFile.delete()
+                }
+                if (destFile.exists() && !partFile.exists()) {
+                    // Resume into .part to avoid treating interrupted final files as complete.
+                    destFile.renameTo(partFile)
+                }
 
                 updateProgress(
                     modelId = model.id,
@@ -100,25 +136,55 @@ class ModelDownloader(
                     fraction = baseFraction
                 )
 
-                Downloader.downloadFile(
-                    url = fileUrl,
-                    target = destFile,
-                    headers = headers
-                ) { downloadedBytes, totalBytes ->
-                    val fileFraction = if (totalBytes > 0L) {
-                        downloadedBytes.toFloat() / totalBytes.toFloat()
-                    } else {
-                        0f
+                DebugLogger.log("ModelDownloader: Downloading ${model.id}/${spec.localPath}")
+                val maxAttempts = 3
+                var attempt = 1
+                while (true) {
+                    try {
+                        Downloader.downloadFile(
+                            url = fileUrl,
+                            target = partFile,
+                            headers = headers
+                        ) { downloadedBytes, totalBytes ->
+                            val fileFraction = if (totalBytes > 0L) {
+                                downloadedBytes.toFloat() / totalBytes.toFloat()
+                            } else {
+                                0f
+                            }
+                            val overall = (index.toFloat() + fileFraction) / totalFiles.toFloat()
+                            updateProgress(
+                                modelId = model.id,
+                                currentFile = displayName,
+                                downloadedBytes = downloadedBytes,
+                                totalBytes = totalBytes,
+                                fraction = overall
+                            )
+                        }.getOrThrow()
+                        break
+                    } catch (e: Exception) {
+                        if (attempt >= maxAttempts) {
+                            throw e
+                        }
+                        val backoffMs = 1500L * attempt
+                        DebugLogger.log(
+                            "ModelDownloader: Retry $attempt/$maxAttempts for ${model.id}/${spec.localPath} after error: ${e.message}"
+                        )
+                        delay(backoffMs)
+                        attempt += 1
                     }
-                    val overall = (index.toFloat() + fileFraction) / totalFiles.toFloat()
-                    updateProgress(
-                        modelId = model.id,
-                        currentFile = displayName,
-                        downloadedBytes = downloadedBytes,
-                        totalBytes = totalBytes,
-                        fraction = overall
+                }
+
+                if (!TtsModelValidator.isFileValid(model.id, spec.localPath, partFile)) {
+                    throw IllegalStateException(
+                        "Downloaded file is invalid/incomplete: ${spec.localPath} (${partFile.length()} bytes)"
                     )
-                }.getOrThrow()
+                }
+                if (destFile.exists()) destFile.delete()
+                if (!partFile.renameTo(destFile)) {
+                    partFile.copyTo(destFile, overwrite = true)
+                    partFile.delete()
+                }
+                DebugLogger.log("ModelDownloader: Completed ${model.id}/${spec.localPath} (${destFile.length()} bytes)")
 
                 val destSize = destFile.length().coerceAtLeast(1L)
                 updateProgress(
@@ -138,11 +204,11 @@ class ModelDownloader(
                 }
             }
 
-            model.isDownloaded = hasAllFiles(targetDir, fileSpecs)
+            model.isDownloaded = hasAllFiles(model.id, targetDir, fileSpecs)
             model.hasPartial = !model.isDownloaded && (partialDir.exists() || targetDir.exists())
             DebugLogger.log("ModelDownloader: Download of ${model.name} completed")
         } catch (e: Exception) {
-            model.isDownloaded = hasAllFiles(targetDir, fileSpecs)
+            model.isDownloaded = hasAllFiles(model.id, targetDir, fileSpecs)
             model.hasPartial = !model.isDownloaded && (partialDir.exists() || targetDir.exists())
             DebugLogger.log("ModelDownloader: Error downloading ${model.name}: ${e.message}")
         } finally {
@@ -253,9 +319,11 @@ class ModelDownloader(
     private fun buildFileUrl(baseUrl: String, remotePath: String): String =
         "$baseUrl${remotePath}?download=true"
 
-    private fun hasAllFiles(rootDir: File, specs: List<DownloadFileSpec>): Boolean {
+    private fun hasAllFiles(modelId: String, rootDir: File, specs: List<DownloadFileSpec>): Boolean {
         if (!rootDir.exists()) return false
-        return specs.all { spec -> File(rootDir, spec.localPath).exists() }
+        return specs.all { spec ->
+            TtsModelValidator.isFileValid(modelId, spec.localPath, File(rootDir, spec.localPath))
+        }
     }
 
     private fun authHeaders(token: String?): Map<String, String> {

--- a/app/src/main/java/com/mewmix/nabu/data/ModelManager.kt
+++ b/app/src/main/java/com/mewmix/nabu/data/ModelManager.kt
@@ -57,21 +57,7 @@ class ModelManager(private val context: Context) {
 
             if (model.type == ModelType.TTS) {
                 val ttsDir = File(modelDir, model.id)
-                var downloaded = ttsDir.exists() && ttsDir.isDirectory && (ttsDir.list()?.isNotEmpty() == true)
-
-                // Validate required files for specific TTS models (e.g., Soprano needs external data)
-                if (downloaded && model.id == "soprano-80m-onnx") {
-                    val required = listOf(
-                        "soprano_backbone_kv.onnx",
-                        "soprano_decoder.onnx",
-                        "soprano_decoder.onnx.data",
-                        "tokenizer.json"
-                    )
-                    val missing = required.any { name -> !File(ttsDir, name).exists() }
-                    if (missing) {
-                        downloaded = false
-                    }
-                }
+                val downloaded = TtsModelValidator.hasAllRequiredFiles(model.id, ttsDir)
 
                 model.isDownloaded = downloaded
                 // Partial check for TTS is simplified or we can check for a temp folder

--- a/app/src/main/java/com/mewmix/nabu/data/TtsModelValidator.kt
+++ b/app/src/main/java/com/mewmix/nabu/data/TtsModelValidator.kt
@@ -1,0 +1,66 @@
+package com.mewmix.nabu.data
+
+import java.io.File
+
+object TtsModelValidator {
+    private const val SOPRANO_MODEL_ID = "soprano-80m-onnx"
+
+    private val sopranoMinBytes = mapOf(
+        "soprano_backbone_kv.onnx" to 200_000_000L,
+        "soprano_decoder.onnx" to 100_000L,
+        "soprano_decoder.onnx.data" to 20_000_000L,
+        "tokenizer.json" to 100_000L
+    )
+
+    fun requiredFiles(modelId: String): List<String> {
+        return when (modelId) {
+            SOPRANO_MODEL_ID -> listOf(
+                "soprano_backbone_kv.onnx",
+                "soprano_decoder.onnx",
+                "soprano_decoder.onnx.data",
+                "tokenizer.json"
+            )
+            else -> emptyList()
+        }
+    }
+
+    fun missingFiles(modelId: String, primaryDir: File, secondaryDir: File? = null): List<String> {
+        val required = requiredFiles(modelId)
+        if (required.isEmpty()) return emptyList()
+        return required.filter { localPath ->
+            val primaryFile = File(primaryDir, localPath)
+            val primaryValid = isFileValid(modelId, localPath, primaryFile)
+            if (primaryValid) {
+                false
+            } else {
+                val secondaryValid = secondaryDir?.let { dir ->
+                    isFileValid(modelId, localPath, File(dir, localPath))
+                } ?: false
+                !secondaryValid
+            }
+        }
+    }
+
+    fun hasAllRequiredFiles(modelId: String, rootDir: File): Boolean {
+        if (!rootDir.exists() || !rootDir.isDirectory) return false
+        val required = requiredFiles(modelId)
+        if (required.isEmpty()) {
+            return rootDir.list()?.isNotEmpty() == true
+        }
+        return required.all { localPath ->
+            isFileValid(modelId, localPath, File(rootDir, localPath))
+        }
+    }
+
+    fun isFileValid(modelId: String, localPath: String, file: File): Boolean {
+        if (!file.exists() || !file.isFile) return false
+        val size = file.length()
+        if (size <= 0L) return false
+
+        val minBytes = when (modelId) {
+            SOPRANO_MODEL_ID -> sopranoMinBytes[localPath]
+            else -> null
+        }
+        return minBytes?.let { size >= it } ?: true
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/galleryport/LlmController.kt
+++ b/app/src/main/java/com/mewmix/nabu/galleryport/LlmController.kt
@@ -2,6 +2,7 @@ package com.mewmix.nabu.galleryport
 
 import android.content.Context
 import com.google.mediapipe.tasks.genai.llminference.*
+import com.mewmix.nabu.chat.VisionModelSupport
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
@@ -10,14 +11,14 @@ import java.io.File
 class LlmController private constructor(val llm: LlmInference) {
 
     companion object {
-        private const val CHAT_MODEL_ID = "gemma-2b-it-cpu"
         fun bootstrap(ctx: Context): LlmController? {
             val modelManager = com.mewmix.nabu.data.ModelManager(ctx)
-            val model = modelManager.getModel(CHAT_MODEL_ID)
-
-            if (model == null || !model.isDownloaded) {
-                return null
-            }
+            val model = modelManager.models.firstOrNull {
+                it.isDownloaded &&
+                    it.type == com.mewmix.nabu.data.ModelType.LLM &&
+                    it.backend == "mediapipe" &&
+                    VisionModelSupport.supportsImageInput(it.id)
+            } ?: return null
 
             val modelFile = File(ctx.filesDir, "models/${model.id}.task")
             if (!modelFile.exists()) return null

--- a/app/src/main/java/com/mewmix/nabu/kokoro/Downloader.kt
+++ b/app/src/main/java/com/mewmix/nabu/kokoro/Downloader.kt
@@ -96,9 +96,8 @@ object Downloader {
     ): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
             target.parentFile?.mkdirs()
-            val contentLength = fetchContentLength(url, headers) ?: -1L
             rangeDownload(url, target, headers) { downloaded ->
-                onProgress(downloaded, contentLength)
+                onProgress(downloaded, -1L)
             }
         }
     }
@@ -172,22 +171,4 @@ object Downloader {
         }
     }
 
-    private fun fetchContentLength(url: String, headers: Map<String, String>): Long? {
-        return try {
-            val requestBuilder = Request.Builder()
-                .url(url)
-                .head()
-                .header("User-Agent", "Nabu/1.0 KokoroDownloader")
-                .header("Accept-Encoding", "identity")
-            headers.forEach { (name, value) ->
-                requestBuilder.header(name, value)
-            }
-            client.newCall(requestBuilder.build()).execute().use { response ->
-                if (!response.isSuccessful) return null
-                response.header("Content-Length")?.toLongOrNull()?.takeIf { it > 0L }
-            }
-        } catch (_: Exception) {
-            null
-        }
-    }
 }

--- a/app/src/main/java/com/mewmix/nabu/screens/InitScreen.kt
+++ b/app/src/main/java/com/mewmix/nabu/screens/InitScreen.kt
@@ -33,6 +33,7 @@ import com.mewmix.nabu.data.ModelDownloader
 import com.mewmix.nabu.data.ModelManager
 import com.mewmix.nabu.data.ModelType
 import com.mewmix.nabu.data.Model
+import com.mewmix.nabu.data.TtsModelValidator
 import com.mewmix.nabu.data.UserPreferencesRepository
 import com.mewmix.nabu.ui.brutalist.BrutalButton
 import com.mewmix.nabu.ui.brutalist.BrutalButtonText
@@ -65,7 +66,8 @@ fun InitScreen(
     val progressMap by modelDownloader.progress.collectAsState()
     val detailedProgressMap by modelDownloader.detailedProgress.collectAsState()
     val ttsModels = modelManager.models.filter { it.type == ModelType.TTS }
-    var selectedModel by remember { mutableStateOf<Model?>(ttsModels.firstOrNull()) }
+    val supertonicModels = ttsModels.filter { it.id.startsWith("supertonic") }
+    var selectedModel by remember { mutableStateOf<Model?>(supertonicModels.firstOrNull()) }
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
@@ -78,8 +80,10 @@ fun InitScreen(
             val completedModel = modelManager.models.firstOrNull { it.id == targetId }
             val completed = completedModel?.isDownloaded == true
             if (completed) {
-                DebugLogger.log("InitScreen: Supertonic download complete for ${completedModel?.name ?: targetId}")
+                DebugLogger.log("InitScreen: TTS download complete for ${completedModel?.name ?: targetId}")
                 downloadTargetId = null
+            } else {
+                DebugLogger.log("InitScreen: TTS download incomplete for ${completedModel?.name ?: targetId}")
             }
         }
     }
@@ -126,7 +130,7 @@ fun InitScreen(
             }
 
             if (engine == "supertonic") {
-                if (ttsModels.isNotEmpty()) {
+                if (supertonicModels.isNotEmpty()) {
                     ExposedDropdownMenuBox(
                         expanded = modelExpanded,
                         onExpandedChange = { modelExpanded = it }
@@ -142,7 +146,7 @@ fun InitScreen(
                             expanded = modelExpanded,
                             onDismissRequest = { modelExpanded = false }
                         ) {
-                            ttsModels.forEach { model ->
+                            supertonicModels.forEach { model ->
                                 DropdownMenuItem(
                                     text = { Text(model.name) },
                                     onClick = {
@@ -269,7 +273,11 @@ fun InitScreen(
                                 )
                             }
                         } else {
-                            val label = if (model.isDownloaded) "Downloaded" else "Download"
+                            val label = when {
+                                model.isDownloaded -> "Downloaded"
+                                model.hasPartial -> "Resume"
+                                else -> "Download"
+                            }
                             BrutalButton(
                                 onClick = {
                                     if (!model.isDownloaded) {
@@ -289,6 +297,31 @@ fun InitScreen(
 
             BrutalButton(
                 onClick = {
+                    if (engine == "supertonic") {
+                        val selected = selectedModel
+                        if (selected == null || !selected.isDownloaded) {
+                            Toast.makeText(
+                                context,
+                                "Select and download a Supertonic model before continuing.",
+                                Toast.LENGTH_LONG
+                            ).show()
+                            return@BrutalButton
+                        }
+                    }
+                    if (engine == "soprano") {
+                        val modelId = "soprano-80m-onnx"
+                        val modelDir = java.io.File(context.filesDir, "models/$modelId")
+                        val partialDir = java.io.File(context.filesDir, "models/${modelId}_partial")
+                        val missing = TtsModelValidator.missingFiles(modelId, modelDir, partialDir)
+                        if (missing.isNotEmpty()) {
+                            Toast.makeText(
+                                context,
+                                "Soprano download incomplete. Missing: ${missing.joinToString()}",
+                                Toast.LENGTH_LONG
+                            ).show()
+                            return@BrutalButton
+                        }
+                    }
                     SettingsManager.setTtsEngine(context, engine)
                     if (engine == "supertonic") {
                         SettingsManager.setSupertonicModelId(context, selectedModel?.id)

--- a/app/src/main/java/com/mewmix/nabu/soprano/SopranoTokenizer.kt
+++ b/app/src/main/java/com/mewmix/nabu/soprano/SopranoTokenizer.kt
@@ -1,10 +1,10 @@
 package com.mewmix.nabu.soprano
 
-import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonParser
 import java.io.File
 
 class SopranoTokenizer(private val modelDir: File) {
-    private val gson = Gson()
     private val vocab: Map<String, Int>
     private val merges: List<Pair<String, String>>
     private val specialTokens: Map<String, Int>
@@ -16,24 +16,22 @@ class SopranoTokenizer(private val modelDir: File) {
             throw IllegalStateException("tokenizer.json not found in ${modelDir.absolutePath}")
         }
 
-        val json = gson.fromJson(tokenizerFile.readText(), TokenizerJson::class.java)
-        vocab = json.model.vocab
-        // Merges can be either "a b" strings or ["a","b"] arrays depending on tokenizer export.
-        merges = json.model.merges.map { merge ->
-            when (merge) {
-                is String -> {
-                    val parts = merge.split(" ")
-                    if (parts.size != 2) throw IllegalStateException("Invalid merge: $merge")
-                    parts[0] to parts[1]
-                }
-                is List<*> -> {
-                    if (merge.size != 2 || merge[0] !is String || merge[1] !is String) {
-                        throw IllegalStateException("Invalid merge list: $merge")
-                    }
-                    (merge[0] as String) to (merge[1] as String)
-                }
-                else -> throw IllegalStateException("Unsupported merge token type: ${merge?.javaClass?.name}")
+        val root = JsonParser.parseString(tokenizerFile.readText()).asJsonObject
+        val model = root.getAsJsonObject("model")
+            ?: throw IllegalStateException("tokenizer.json missing model object")
+        val vocabJson = model.getAsJsonObject("vocab")
+            ?: throw IllegalStateException("tokenizer.json missing vocab object")
+        vocab = buildMap(vocabJson.entrySet().size) {
+            for ((token, idElement) in vocabJson.entrySet()) {
+                put(token, idElement.asInt)
             }
+        }
+
+        // Merges can be either "a b" strings or ["a","b"] arrays depending on tokenizer export.
+        val mergesJson = model.getAsJsonArray("merges")
+            ?: throw IllegalStateException("tokenizer.json missing merges array")
+        merges = List(mergesJson.size()) { index ->
+            parseMergeEntry(mergesJson[index])
         }
 
         // Identify special tokens. Usually defined in added_tokens or just vocab with specific format.
@@ -132,13 +130,29 @@ class SopranoTokenizer(private val modelDir: File) {
         return ids.joinToString("") { reverseVocab[it.toInt()] ?: "" }
     }
 
-    // JSON Structure
-    private data class TokenizerJson(
-        val model: Model
-    )
-
-    private data class Model(
-        val vocab: Map<String, Int>,
-        val merges: List<Any>
-    )
+    private fun parseMergeEntry(value: JsonElement): Pair<String, String> {
+        return when {
+            value.isJsonPrimitive && value.asJsonPrimitive.isString -> {
+                val merge = value.asString
+                val parts = merge.split(" ")
+                if (parts.size != 2) throw IllegalStateException("Invalid merge: $merge")
+                parts[0] to parts[1]
+            }
+            value.isJsonArray -> {
+                val mergeArray = value.asJsonArray
+                if (mergeArray.size() != 2) {
+                    throw IllegalStateException("Invalid merge list length: ${mergeArray.size()}")
+                }
+                val first = mergeArray[0]
+                val second = mergeArray[1]
+                if (!first.isJsonPrimitive || !first.asJsonPrimitive.isString ||
+                    !second.isJsonPrimitive || !second.asJsonPrimitive.isString
+                ) {
+                    throw IllegalStateException("Invalid merge list: $mergeArray")
+                }
+                first.asString to second.asString
+            }
+            else -> throw IllegalStateException("Unsupported merge token type: $value")
+        }
+    }
 }

--- a/app/src/main/java/com/mewmix/nabu/tts/TTSManager.kt
+++ b/app/src/main/java/com/mewmix/nabu/tts/TTSManager.kt
@@ -9,6 +9,7 @@ import com.mewmix.nabu.utils.DebugLogger
 import com.mewmix.nabu.utils.OnnxRuntimeManager
 import java.io.File
 import com.mewmix.nabu.data.ModelManager
+import com.mewmix.nabu.data.TtsModelValidator
 import ai.onnxruntime.OrtEnvironment
 import com.mewmix.nabu.utils.SettingsManager
 import com.mewmix.nabu.kokoro.RunEp
@@ -108,18 +109,35 @@ object TTSManager {
             DebugLogger.log("TTSManager: Preference=Soprano. Verifying local model files...")
             val modelId = SOPRANO_MODEL_ID
             val modelDir = File(context.filesDir, "models/$modelId")
-            val required = listOf(
-                "soprano_backbone_kv.onnx",
-                "soprano_decoder.onnx",
-                "soprano_decoder.onnx.data",
-                "tokenizer.json"
-            )
-            val missing = required.filter { !File(modelDir, it).exists() }
+            val partialDir = File(context.filesDir, "models/${modelId}_partial")
+            val validInTarget = TtsModelValidator.hasAllRequiredFiles(modelId, modelDir)
+            val validInPartial = TtsModelValidator.hasAllRequiredFiles(modelId, partialDir)
 
-            if (missing.isEmpty()) {
+            val resolvedModelDir = when {
+                validInTarget -> modelDir
+                validInPartial -> {
+                    DebugLogger.log("TTSManager: Soprano complete in partial dir; promoting to final dir")
+                    val promoted = runCatching {
+                        if (modelDir.exists()) modelDir.deleteRecursively()
+                        if (!partialDir.renameTo(modelDir)) {
+                            partialDir.copyRecursively(modelDir, overwrite = true)
+                            partialDir.deleteRecursively()
+                        }
+                        modelDir
+                    }.getOrElse {
+                        DebugLogger.log("TTSManager: Failed to promote partial soprano dir: ${it.message}")
+                        partialDir
+                    }
+                    promoted
+                }
+                else -> null
+            }
+            val missing = TtsModelValidator.missingFiles(modelId, modelDir, partialDir)
+
+            if (resolvedModelDir != null) {
                 try {
-                    DebugLogger.log("TTSManager: Loading Soprano from ${modelDir.absolutePath}")
-                    val engine = SopranoEngine(modelDir, OrtEnvironment.getEnvironment())
+                    DebugLogger.log("TTSManager: Loading Soprano from ${resolvedModelDir.absolutePath}")
+                    val engine = SopranoEngine(resolvedModelDir, OrtEnvironment.getEnvironment())
                     activeEngine = BenchmarkingTTSEngine(engine)
                     activeEngineKind = EngineKind.SOPRANO
                     activeRuntimePreference = RunEp.CPU

--- a/app/src/main/java/com/mewmix/nabu/ui/components/RuntimeStatusLine.kt
+++ b/app/src/main/java/com/mewmix/nabu/ui/components/RuntimeStatusLine.kt
@@ -8,9 +8,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.mewmix.nabu.data.ModelManager
 import com.mewmix.nabu.data.ModelType
+import com.mewmix.nabu.data.TtsModelValidator
 import com.mewmix.nabu.ui.brutalist.Brutal
 import com.mewmix.nabu.utils.OnnxRuntimeManager
 import com.mewmix.nabu.utils.SettingsManager
+import java.io.File
 
 @Composable
 fun RuntimeStatusLine(
@@ -25,6 +27,10 @@ fun RuntimeStatusLine(
         modelManager.models.firstOrNull { it.type == ModelType.TTS && it.id == id }?.name
     }
     val supertonicModelLabel = supertonicModelName ?: supertonicModelId
+    val sopranoModelId = "soprano-80m-onnx"
+    val sopranoDir = File(context.filesDir, "models/$sopranoModelId")
+    val sopranoPartialDir = File(context.filesDir, "models/${sopranoModelId}_partial")
+    val sopranoMissing = TtsModelValidator.missingFiles(sopranoModelId, sopranoDir, sopranoPartialDir)
 
     val runtimeLabel = if (ttsEngine == "supertonic") {
         buildString {
@@ -32,7 +38,11 @@ fun RuntimeStatusLine(
             supertonicModelLabel?.let { append(" / $it") }
         }
     } else if (ttsEngine == "soprano") {
-        "SOPRANO / CPU / soprano-80m-onnx"
+        if (sopranoMissing.isEmpty()) {
+            "SOPRANO / CPU / soprano-80m-onnx"
+        } else {
+            "SOPRANO / CPU / incomplete download (${sopranoMissing.size} missing)"
+        }
     } else {
         if (runtimeStatus == null) {
             "KOKORO / LOADING..."

--- a/app/src/test/java/com/mewmix/nabu/chat/VisionModelSupportTest.kt
+++ b/app/src/test/java/com/mewmix/nabu/chat/VisionModelSupportTest.kt
@@ -1,0 +1,20 @@
+package com.mewmix.nabu.chat
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VisionModelSupportTest {
+    @Test
+    fun allowlistIsStrict() {
+        assertTrue(VisionModelSupport.supportsImageInput("gemma-3n-E4B-it-int4"))
+        assertFalse(VisionModelSupport.supportsImageInput("gemma3-1b-it-q4"))
+        assertFalse(VisionModelSupport.supportsImageInput("qwen2.5-1.5b-instruct-q8"))
+    }
+
+    @Test
+    fun capabilitiesReflectVisionSupport() {
+        assertTrue(VisionModelSupport.capabilitiesFor("gemma-3n-E4B-it-int4").contains("multimodal"))
+        assertFalse(VisionModelSupport.capabilitiesFor("gemma3-1b-it-q4").contains("multimodal"))
+    }
+}

--- a/app/src/test/java/com/mewmix/nabu/data/TtsModelValidatorTest.kt
+++ b/app/src/test/java/com/mewmix/nabu/data/TtsModelValidatorTest.kt
@@ -1,0 +1,42 @@
+package com.mewmix.nabu.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.charset.StandardCharsets
+import kotlin.io.path.createTempDirectory
+
+class TtsModelValidatorTest {
+    @Test
+    fun sopranoRequiresAllFiles() {
+        val root = createTempDirectory(prefix = "soprano-validator-missing").toFile()
+        createSizedFile(File(root, "soprano_backbone_kv.onnx"), 200_000_001L)
+        assertFalse(TtsModelValidator.hasAllRequiredFiles("soprano-80m-onnx", root))
+    }
+
+    @Test
+    fun sopranoRejectsTooSmallFiles() {
+        val root = createTempDirectory(prefix = "soprano-validator-small").toFile()
+        File(root, "soprano_backbone_kv.onnx").writeBytes(ByteArray(10))
+        File(root, "soprano_decoder.onnx").writeBytes(ByteArray(10))
+        File(root, "soprano_decoder.onnx.data").writeBytes(ByteArray(10))
+        File(root, "tokenizer.json").writeBytes("{}".toByteArray(StandardCharsets.UTF_8))
+        assertFalse(TtsModelValidator.hasAllRequiredFiles("soprano-80m-onnx", root))
+    }
+
+    @Test
+    fun nonSopranoAcceptsNonEmptyDirectory() {
+        val root = createTempDirectory(prefix = "tts-validator-generic").toFile()
+        File(root, "duration_predictor.onnx").writeBytes(byteArrayOf(1))
+        assertTrue(TtsModelValidator.hasAllRequiredFiles("supertonic-onnx", root))
+    }
+
+    private fun createSizedFile(file: File, sizeBytes: Long) {
+        file.parentFile?.mkdirs()
+        RandomAccessFile(file, "rw").use { raf ->
+            raf.setLength(sizeBytes)
+        }
+    }
+}

--- a/app/src/test/java/com/mewmix/nabu/soprano/SopranoTokenizerTest.kt
+++ b/app/src/test/java/com/mewmix/nabu/soprano/SopranoTokenizerTest.kt
@@ -1,0 +1,42 @@
+package com.mewmix.nabu.soprano
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class SopranoTokenizerTest {
+    @Test
+    fun parsesTokenizerJsonAndEncodesSpecialTokens() {
+        val modelDir = createTempDirectory(prefix = "soprano-tokenizer-test").toFile()
+        val tokenizerJson = """
+            {
+              "model": {
+                "vocab": {
+                  "[UNK]": 0,
+                  "[STOP]": 1,
+                  "[TEXT]": 2,
+                  "[START]": 3,
+                  "h": 4,
+                  "i": 5,
+                  "hi": 6
+                },
+                "merges": [
+                  "h i",
+                  ["x", "y"]
+                ]
+              }
+            }
+        """.trimIndent()
+
+        File(modelDir, "tokenizer.json").writeText(tokenizerJson)
+        val tokenizer = SopranoTokenizer(modelDir)
+
+        assertArrayEquals(
+            longArrayOf(1L, 6L, 3L),
+            tokenizer.encode("[STOP]hi[START]")
+        )
+        assertEquals("hi", tokenizer.decode(longArrayOf(6L)))
+    }
+}


### PR DESCRIPTION
## Summary
- add strict ask-image model gating via allowlist + backend capability checks
- support image parsing across /generate and /v1/chat/completions with clear validation
- support optional non-stream LLM reply TTS output
- expose model capabilities in /models and /v1/models
- add unit + instrumented tests for gating/validation paths

## Testing
- ./gradlew :app:testDebugUnitTest --no-daemon
- ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.mewmix.nabu.api.ApiServerInstrumentedTest --no-daemon
