### PR TITLE
Add scheduled actions, fuzzy scheduling tools, and LAN IP display

### DIFF
--- a/app/src/main/java/com/mewmix/nabu/actions/ActionTools.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/ActionTools.kt
@@ -1,0 +1,162 @@
+package com.mewmix.nabu.actions
+
+import android.content.Context
+import com.mewmix.nabu.tools.Tool
+import com.mewmix.nabu.tools.ToolCall
+import com.mewmix.nabu.tools.ToolResult
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+object ActionTools {
+    val tools: List<Tool> = listOf(
+        Tool(
+            name = "schedule_action",
+            description = "Schedule a reminder/action at a specific local date-time.",
+            parameters = mapOf(
+                "instruction" to "What should happen when due.",
+                "run_at_local" to "Local datetime in yyyy-MM-dd HH:mm format.",
+                "title" to "Short title.",
+                "recurrence" to "none, daily, or weekly"
+            )
+        ),
+        Tool(
+            name = "schedule_fuzzy_action",
+            description = "Interpret a fuzzy scheduling request and create a scheduled action when possible.",
+            parameters = mapOf(
+                "request" to "Natural-language request like: remind me when the sun goes down in Berlin"
+            )
+        ),
+        Tool(
+            name = "list_scheduled_actions",
+            description = "List pending scheduled actions.",
+            parameters = emptyMap()
+        ),
+        Tool(
+            name = "search_web_context",
+            description = "Search the web for context and return concise findings.",
+            parameters = mapOf(
+                "query" to "What to search for."
+            )
+        )
+    )
+
+    fun execute(context: Context, call: ToolCall): ToolResult? {
+        return when (call.toolName) {
+            "schedule_action" -> runScheduleAction(context, call)
+            "schedule_fuzzy_action" -> runFuzzyAction(context, call)
+            "list_scheduled_actions" -> runListActions(context)
+            "search_web_context" -> runWebSearch(call)
+            else -> null
+        }
+    }
+
+    private fun runScheduleAction(context: Context, call: ToolCall): ToolResult {
+        val instruction = call.arguments["instruction"]?.toString()?.trim().orEmpty()
+        val runAtLocal = call.arguments["run_at_local"]?.toString()?.trim().orEmpty()
+        val title = call.arguments["title"]?.toString()?.trim().ifNullOrBlank("Scheduled action")
+        val recurrence = call.arguments["recurrence"]?.toString()?.trim()?.lowercase().normalizeRecurrence()
+
+        if (instruction.isBlank()) {
+            return ToolResult(call.toolName, "Missing required parameter: instruction", true)
+        }
+        if (runAtLocal.isBlank()) {
+            return ToolResult(call.toolName, "Missing required parameter: run_at_local", true)
+        }
+
+        val triggerAt = parseLocalDateTime(runAtLocal)
+            ?: return ToolResult(call.toolName, "Invalid run_at_local format. Use yyyy-MM-dd HH:mm", true)
+
+        val action = ScheduledActionScheduler.createAndSchedule(
+            context = context,
+            title = title,
+            instruction = instruction,
+            triggerAtEpochMs = triggerAt,
+            recurrence = recurrence
+        )
+
+        return ToolResult(
+            call.toolName,
+            "Scheduled '${action.title}' for ${formatEpoch(action.triggerAtEpochMs)} (recurrence=${action.recurrence}, id=${action.id})."
+        )
+    }
+
+    private fun runFuzzyAction(context: Context, call: ToolCall): ToolResult {
+        val request = call.arguments["request"]?.toString()?.trim().orEmpty()
+        if (request.isBlank()) {
+            return ToolResult(call.toolName, "Missing required parameter: request", true)
+        }
+        val resolved = FuzzyActionInterpreter.resolveInstruction(request)
+            ?: inferFromWeb(request)
+            ?: return ToolResult(
+                call.toolName,
+                "I couldn't confidently parse that request yet. Try explicit schedule_action with run_at_local.",
+                true
+            )
+
+        val action = ScheduledActionScheduler.createAndSchedule(
+            context,
+            resolved.title,
+            resolved.instruction,
+            resolved.triggerAtEpochMs,
+            resolved.recurrence
+        )
+
+        return ToolResult(
+            call.toolName,
+            "Scheduled fuzzy action '${action.title}' for ${formatEpoch(action.triggerAtEpochMs)} (recurrence=${action.recurrence}, id=${action.id})."
+        )
+    }
+
+    private fun runListActions(context: Context): ToolResult {
+        val actions = ScheduledActionStore.list(context)
+        if (actions.isEmpty()) return ToolResult("list_scheduled_actions", "No scheduled actions.")
+        val lines = actions.joinToString("\n") {
+            "- ${it.title} at ${formatEpoch(it.triggerAtEpochMs)} (recurrence=${it.recurrence}, id=${it.id})"
+        }
+        return ToolResult("list_scheduled_actions", lines)
+    }
+
+    private fun runWebSearch(call: ToolCall): ToolResult {
+        val query = call.arguments["query"]?.toString()?.trim().orEmpty()
+        if (query.isBlank()) {
+            return ToolResult(call.toolName, "Missing required parameter: query", true)
+        }
+        val hits = WebActionReasoner.search(query)
+        return ToolResult(call.toolName, WebActionReasoner.summarize(hits))
+    }
+
+    private fun inferFromWeb(request: String): FuzzyActionInterpreter.ResolvedAction? {
+        val inferredTime = WebActionReasoner.inferTimeFromWeb(request) ?: return null
+        return FuzzyActionInterpreter.ResolvedAction(
+            title = "Web-inferred reminder",
+            instruction = request.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() },
+            triggerAtEpochMs = inferredTime,
+            recurrence = ScheduledAction.RECURRENCE_NONE
+        )
+    }
+
+    private fun parseLocalDateTime(value: String): Long? {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+        return runCatching {
+            LocalDateTime.parse(value, formatter)
+                .atZone(ZoneId.systemDefault())
+                .toInstant()
+                .toEpochMilli()
+        }.getOrNull()
+    }
+
+    private fun formatEpoch(epochMs: Long): String =
+        java.time.Instant.ofEpochMilli(epochMs)
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime()
+            .toString()
+
+    private fun String?.ifNullOrBlank(default: String): String = if (this.isNullOrBlank()) default else this
+
+    private fun String?.normalizeRecurrence(): String = when (this) {
+        ScheduledAction.RECURRENCE_DAILY -> ScheduledAction.RECURRENCE_DAILY
+        ScheduledAction.RECURRENCE_WEEKLY -> ScheduledAction.RECURRENCE_WEEKLY
+        else -> ScheduledAction.RECURRENCE_NONE
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/actions/FuzzyActionInterpreter.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/FuzzyActionInterpreter.kt
@@ -1,0 +1,85 @@
+package com.mewmix.nabu.actions
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.net.URLEncoder
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object FuzzyActionInterpreter {
+    private val client = OkHttpClient()
+    private val sunsetRegex = Regex("""remind me when the sun (goes down|sets) in (.+)""", RegexOption.IGNORE_CASE)
+
+    fun resolveInstruction(raw: String): ResolvedAction? {
+        val trimmed = raw.trim()
+        if (trimmed.isBlank()) return null
+
+        val sunsetMatch = sunsetRegex.matchEntire(trimmed)
+        if (sunsetMatch != null) {
+            val location = sunsetMatch.groupValues[2].trim().trimEnd('.', '!', '?')
+            return resolveSunsetReminder(location)
+        }
+
+        return null
+    }
+
+    private fun resolveSunsetReminder(location: String): ResolvedAction? {
+        val encoded = URLEncoder.encode(location, Charsets.UTF_8.name())
+        val geoUrl = "https://geocoding-api.open-meteo.com/v1/search?name=$encoded&count=1"
+        val geoResp = fetchJson(geoUrl) ?: return null
+        val geoResult = geoResp.optJSONArray("results")?.optJSONObject(0) ?: return null
+        val lat = geoResult.optDouble("latitude", Double.NaN)
+        val lon = geoResult.optDouble("longitude", Double.NaN)
+        if (lat.isNaN() || lon.isNaN()) return null
+
+        val today = LocalDate.now(ZoneId.systemDefault())
+        val forecastUrl = "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon&daily=sunset&timezone=auto&start_date=$today&end_date=$today"
+        val sunsetResp = fetchJson(forecastUrl) ?: return null
+        val sunsetIso = sunsetResp
+            .optJSONObject("daily")
+            ?.optJSONArray("sunset")
+            ?.optString(0)
+            ?.trim()
+            .orEmpty()
+        if (sunsetIso.isBlank()) return null
+
+        val sunsetEpochMs = runCatching { Instant.parse(sunsetIso).toEpochMilli() }.getOrElse {
+            runCatching {
+                LocalDateTime.parse(sunsetIso).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+            }.getOrNull()
+        } ?: return null
+
+        val nextTrigger = if (sunsetEpochMs <= System.currentTimeMillis()) {
+            sunsetEpochMs + (24L * 60L * 60L * 1000L)
+        } else {
+            sunsetEpochMs
+        }
+
+        return ResolvedAction(
+            title = "Sunset reminder: $location",
+            instruction = "Sunset is happening now in $location.",
+            triggerAtEpochMs = nextTrigger,
+            recurrence = ScheduledAction.RECURRENCE_DAILY
+        )
+    }
+
+    private fun fetchJson(url: String): JSONObject? {
+        val request = Request.Builder().url(url).header("User-Agent", "Nabu/1.0").build()
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return null
+                JSONObject(response.body?.string().orEmpty())
+            }
+        }.getOrNull()
+    }
+
+    data class ResolvedAction(
+        val title: String,
+        val instruction: String,
+        val triggerAtEpochMs: Long,
+        val recurrence: String
+    )
+}

--- a/app/src/main/java/com/mewmix/nabu/actions/ScheduledAction.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/ScheduledAction.kt
@@ -1,0 +1,16 @@
+package com.mewmix.nabu.actions
+
+data class ScheduledAction(
+    val id: String,
+    val title: String,
+    val instruction: String,
+    val triggerAtEpochMs: Long,
+    val recurrence: String = RECURRENCE_NONE,
+    val createdAtEpochMs: Long = System.currentTimeMillis()
+) {
+    companion object {
+        const val RECURRENCE_NONE = "none"
+        const val RECURRENCE_DAILY = "daily"
+        const val RECURRENCE_WEEKLY = "weekly"
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/actions/ScheduledActionScheduler.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/ScheduledActionScheduler.kt
@@ -1,0 +1,52 @@
+package com.mewmix.nabu.actions
+
+import android.content.Context
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+object ScheduledActionScheduler {
+    fun schedule(context: Context, action: ScheduledAction) {
+        val delayMs = (action.triggerAtEpochMs - System.currentTimeMillis()).coerceAtLeast(0L)
+        val input = Data.Builder()
+            .putString(ScheduledActionWorker.KEY_ACTION_ID, action.id)
+            .putString(ScheduledActionWorker.KEY_TITLE, action.title)
+            .putString(ScheduledActionWorker.KEY_INSTRUCTION, action.instruction)
+            .putLong(ScheduledActionWorker.KEY_TRIGGER_AT, action.triggerAtEpochMs)
+            .putString(ScheduledActionWorker.KEY_RECURRENCE, action.recurrence)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<ScheduledActionWorker>()
+            .setInitialDelay(delayMs, TimeUnit.MILLISECONDS)
+            .setInputData(input)
+            .addTag(ScheduledActionWorker.TAG)
+            .build()
+
+        WorkManager.getInstance(context.applicationContext)
+            .enqueueUniqueWork(uniqueName(action.id), ExistingWorkPolicy.REPLACE, request)
+        ScheduledActionStore.upsert(context.applicationContext, action)
+    }
+
+    fun createAndSchedule(
+        context: Context,
+        title: String,
+        instruction: String,
+        triggerAtEpochMs: Long,
+        recurrence: String
+    ): ScheduledAction {
+        val action = ScheduledAction(
+            id = UUID.randomUUID().toString(),
+            title = title,
+            instruction = instruction,
+            triggerAtEpochMs = triggerAtEpochMs,
+            recurrence = recurrence
+        )
+        schedule(context, action)
+        return action
+    }
+
+    private fun uniqueName(actionId: String): String = "scheduled_action_$actionId"
+}

--- a/app/src/main/java/com/mewmix/nabu/actions/ScheduledActionStore.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/ScheduledActionStore.kt
@@ -1,0 +1,33 @@
+package com.mewmix.nabu.actions
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.mewmix.nabu.utils.DatabaseManager
+
+object ScheduledActionStore {
+    private const val KEY_SCHEDULED_ACTIONS = "scheduled_actions"
+    private val gson = Gson()
+    private val listType = TypeToken.getParameterized(List::class.java, ScheduledAction::class.java).type
+
+    fun list(context: Context): List<ScheduledAction> {
+        val raw = DatabaseManager.getSetting(context, KEY_SCHEDULED_ACTIONS).orEmpty()
+        if (raw.isBlank()) return emptyList()
+        return runCatching {
+            gson.fromJson<List<ScheduledAction>>(raw, listType).orEmpty()
+        }.getOrDefault(emptyList())
+    }
+
+    fun upsert(context: Context, action: ScheduledAction) {
+        val next = list(context)
+            .filterNot { it.id == action.id }
+            .plus(action)
+            .sortedBy { it.triggerAtEpochMs }
+        DatabaseManager.setSetting(context, KEY_SCHEDULED_ACTIONS, gson.toJson(next, listType))
+    }
+
+    fun remove(context: Context, actionId: String) {
+        val next = list(context).filterNot { it.id == actionId }
+        DatabaseManager.setSetting(context, KEY_SCHEDULED_ACTIONS, gson.toJson(next, listType))
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/actions/ScheduledActionWorker.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/ScheduledActionWorker.kt
@@ -1,0 +1,79 @@
+package com.mewmix.nabu.actions
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.mewmix.nabu.R
+import kotlin.math.absoluteValue
+
+class ScheduledActionWorker(
+    context: Context,
+    params: WorkerParameters
+) : Worker(context, params) {
+
+    override fun doWork(): Result {
+        val actionId = inputData.getString(KEY_ACTION_ID).orEmpty()
+        val title = inputData.getString(KEY_TITLE).orEmpty().ifBlank { "Scheduled action" }
+        val instruction = inputData.getString(KEY_INSTRUCTION).orEmpty().ifBlank { "Action is due now." }
+        val triggerAt = inputData.getLong(KEY_TRIGGER_AT, System.currentTimeMillis())
+        val recurrence = inputData.getString(KEY_RECURRENCE).orEmpty().ifBlank { ScheduledAction.RECURRENCE_NONE }
+
+        ensureChannel()
+        NotificationManagerCompat.from(applicationContext).notify(
+            actionId.hashCode().absoluteValue,
+            NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_chat_24)
+                .setContentTitle(title)
+                .setContentText(instruction)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(instruction))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true)
+                .build()
+        )
+
+        if (recurrence == ScheduledAction.RECURRENCE_DAILY || recurrence == ScheduledAction.RECURRENCE_WEEKLY) {
+            val step = if (recurrence == ScheduledAction.RECURRENCE_WEEKLY) {
+                7L * 24L * 60L * 60L * 1000L
+            } else {
+                24L * 60L * 60L * 1000L
+            }
+            val next = ScheduledAction(
+                id = actionId,
+                title = title,
+                instruction = instruction,
+                triggerAtEpochMs = triggerAt + step,
+                recurrence = recurrence
+            )
+            ScheduledActionScheduler.schedule(applicationContext, next)
+        } else {
+            ScheduledActionStore.remove(applicationContext, actionId)
+        }
+
+        return Result.success()
+    }
+
+    private fun ensureChannel() {
+        val manager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Scheduled Actions",
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        manager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val TAG = "scheduled_action"
+        const val CHANNEL_ID = "scheduled_action_channel"
+        const val KEY_ACTION_ID = "action_id"
+        const val KEY_TITLE = "title"
+        const val KEY_INSTRUCTION = "instruction"
+        const val KEY_TRIGGER_AT = "trigger_at"
+        const val KEY_RECURRENCE = "recurrence"
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/actions/WebActionReasoner.kt
+++ b/app/src/main/java/com/mewmix/nabu/actions/WebActionReasoner.kt
@@ -1,0 +1,109 @@
+package com.mewmix.nabu.actions
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jsoup.Jsoup
+import java.net.URLEncoder
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+
+object WebActionReasoner {
+    private val client = OkHttpClient()
+    private val monthFormatters = listOf(
+        DateTimeFormatter.ofPattern("MMMM d, yyyy h:mm a", Locale.US),
+        DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a", Locale.US)
+    )
+    private val isoFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
+    data class SearchHit(val title: String, val snippet: String, val url: String)
+
+    fun search(query: String, limit: Int = 5): List<SearchHit> {
+        if (query.isBlank()) return emptyList()
+        val encoded = URLEncoder.encode(query, Charsets.UTF_8.name())
+        val url = "https://duckduckgo.com/html/?q=$encoded"
+        val req = Request.Builder().url(url).header("User-Agent", "Nabu/1.0").build()
+        return runCatching {
+            client.newCall(req).execute().use { response ->
+                if (!response.isSuccessful) return emptyList()
+                val html = response.body?.string().orEmpty()
+                val doc = Jsoup.parse(html)
+                doc.select(".result")
+                    .take(limit)
+                    .mapNotNull { node ->
+                        val titleNode = node.selectFirst(".result__a") ?: return@mapNotNull null
+                        val snippet = node.selectFirst(".result__snippet")?.text().orEmpty().trim()
+                        SearchHit(
+                            title = titleNode.text().trim(),
+                            snippet = snippet,
+                            url = titleNode.attr("href").trim()
+                        )
+                    }
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    fun inferTimeFromWeb(request: String): Long? {
+        val hits = search(request)
+        if (hits.isEmpty()) return null
+        val now = System.currentTimeMillis()
+        val candidates = mutableListOf<Long>()
+        hits.forEach { hit ->
+            candidates += parseDateTimes("${hit.title} ${hit.snippet}")
+        }
+        return candidates.sorted().firstOrNull { it > now }
+    }
+
+    fun summarize(hits: List<SearchHit>): String {
+        if (hits.isEmpty()) return "No web results found."
+        return hits.joinToString("\n") { "- ${it.title}: ${it.snippet} (${it.url})" }
+    }
+
+    private fun parseDateTimes(text: String): List<Long> {
+        val results = mutableListOf<Long>()
+        val isoMatches = Regex("""\b(\d{4}-\d{2}-\d{2})[ T](\d{1,2}:\d{2})\b""")
+            .findAll(text)
+            .map { "${it.groupValues[1]} ${it.groupValues[2]}" }
+            .toList()
+        isoMatches.forEach { raw ->
+            runCatching {
+                LocalDateTime.parse(raw, isoFormatter)
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli()
+            }.getOrNull()?.let(results::add)
+        }
+
+        val monthRegex = Regex("""\b([A-Z][a-z]{2,8}\s+\d{1,2},\s+\d{4}\s+\d{1,2}:\d{2}\s*(AM|PM|am|pm))\b""")
+        monthRegex.findAll(text).forEach { m ->
+            val raw = m.groupValues[1].uppercase().replace("AM", " AM").replace("PM", " PM").replace("  ", " ").trim()
+            monthFormatters.forEach { formatter ->
+                try {
+                    val parsed = LocalDateTime.parse(raw, formatter)
+                        .atZone(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli()
+                    results += parsed
+                    return@forEach
+                } catch (_: DateTimeParseException) {
+                }
+            }
+        }
+
+        val timeOnlyRegex = Regex("""\b(\d{1,2}:\d{2})\s*(AM|PM|am|pm)\b""")
+        timeOnlyRegex.findAll(text).forEach { match ->
+            val raw = "${LocalDate.now()} ${match.groupValues[1]} ${match.groupValues[2].uppercase()}"
+            runCatching {
+                LocalDateTime.parse(raw, DateTimeFormatter.ofPattern("yyyy-MM-dd h:mm a", Locale.US))
+                    .atZone(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli()
+            }.getOrNull()?.let(results::add)
+        }
+
+        return results
+    }
+}

--- a/app/src/main/java/com/mewmix/nabu/api/ApiServerManager.kt
+++ b/app/src/main/java/com/mewmix/nabu/api/ApiServerManager.kt
@@ -3,6 +3,8 @@ package com.mewmix.nabu.api
 import android.content.Context
 import com.mewmix.nabu.utils.DebugLogger
 import com.mewmix.nabu.utils.SettingsManager
+import java.util.Collections
+import java.net.NetworkInterface
 
 object ApiServerManager {
     const val LOCAL_HOST: String = "127.0.0.1"
@@ -56,6 +58,22 @@ object ApiServerManager {
 
     fun currentPort(): Int = synchronized(lock) {
         resolvedPort()
+    }
+
+    fun localLanIpAddress(): String? {
+        return runCatching {
+            val interfaces = NetworkInterface.getNetworkInterfaces() ?: return null
+            Collections.list(interfaces)
+                .asSequence()
+                .filter { it.isUp && !it.isLoopback }
+                .flatMap { Collections.list(it.inetAddresses).asSequence() }
+                .firstOrNull { address ->
+                    !address.isLoopbackAddress &&
+                        !address.isLinkLocalAddress &&
+                        address.hostAddress?.contains(':') == false
+                }
+                ?.hostAddress
+        }.getOrNull()
     }
 
     fun stop() {

--- a/app/src/main/java/com/mewmix/nabu/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/mewmix/nabu/screens/SettingsScreen.kt
@@ -216,14 +216,19 @@ fun SettingsScreen(
             if (apiEnabled) {
                 val host = ApiServerManager.currentHost() ?: ApiServerManager.configuredHost(context.applicationContext)
                 val port = ApiServerManager.currentPort()
+                val lanIp = if (apiLanEnabled) ApiServerManager.localLanIpAddress() else null
                 Text(
-                    text = "Listening on http://$host:$port",
+                    text = if (lanIp != null) "Listening on http://$lanIp:$port (bound: $host)" else "Listening on http://$host:$port",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurface
                 )
                 if (apiLanEnabled) {
                     Text(
-                        text = "LAN mode: use your device IP on the same network.",
+                        text = if (lanIp != null) {
+                            "LAN mode: share http://$lanIp:$port on the same network."
+                        } else {
+                            "LAN mode is enabled; connect to your device IP on the same network."
+                        },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface
                     )

--- a/app/src/main/java/com/mewmix/nabu/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/mewmix/nabu/viewmodel/ChatViewModel.kt
@@ -46,6 +46,7 @@ import com.mewmix.nabu.tools.ToolCall
 import com.mewmix.nabu.tools.ToolCallProtocol
 import com.mewmix.nabu.tools.ToolRegistry
 import com.mewmix.nabu.tools.ToolResult
+import com.mewmix.nabu.actions.ActionTools
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -152,6 +153,7 @@ class ChatViewModel(
     init {
         viewModelScope.launch(Dispatchers.IO) {
             OnnxRuntimeManager.initialize(context.applicationContext)
+            ActionTools.tools.forEach { ToolRegistry.register(it) }
 
             // Initialize Glaive tools if available
             if (GlaiveBridge.isInstalled(context.applicationContext)) {
@@ -348,6 +350,7 @@ class ChatViewModel(
                         isError = true
                     )
                 }
+                ActionTools.execute(appContext, toolCall)?.let { return it }
                 if (!GlaiveBridge.isInstalled(appContext)) {
                     return ToolResult(
                         toolName = toolCall.toolName,

--- a/app/src/main/res/raw/model_allowlist.json
+++ b/app/src/main/res/raw/model_allowlist.json
@@ -24,9 +24,9 @@
     "type": "LLM"
   },
   "gemma-4-E2B-it": {
-    "name": "Gemma 4 E2B IT",
+    "name": "Gemma 4 E2B IT (LiteRT Community)",
     "description": "The smaller Gemma 4 instruction-tuned LiteRT-LM model for Android",
-    "repo": "litert-community/gemma-4-E2B-it-litert-lm",
+    "repo": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/tree/main",
     "downloadUrl": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm",
     "gated": false,
     "type": "LLM"


### PR DESCRIPTION
### Motivation
- Provide a first-class scheduling system so the app can create, persist and trigger reminders/actions at specified times or via fuzzy natural-language requests. 
- Allow the assistant to resolve fuzzy requests (e.g. "remind me when the sun sets in Berlin") using geocoding and weather APIs and to fall back to web reasoning when needed. 
- Expose these capabilities as tools that can be invoked by the assistant runtime, and improve settings visibility by showing the device LAN IP when API-on-LAN is enabled. 

### Description
- Added a tool layer `ActionTools` and registered its tools on startup so scheduling/search tools are available via `ToolRegistry`, and made `ChatViewModel` consult `ActionTools.execute` before delegating to `GlaiveBridge`. 
- Implemented scheduling primitives: `ScheduledAction` model, `ScheduledActionStore` persistence (via `DatabaseManager`), `ScheduledActionScheduler` that enqueues work with `WorkManager`, and `ScheduledActionWorker` that posts notifications and re-schedules recurring items. 
- Implemented fuzzy interpretation and web reasoning: `FuzzyActionInterpreter` resolves sunset reminders via open-meteo geocoding/forecast APIs, and `WebActionReasoner` performs DuckDuckGo searches and extracts potential datetimes to infer trigger times. 
- Added `ApiServerManager.localLanIpAddress()` to obtain the device LAN IP, and updated `SettingsScreen` to surface the LAN IP and improved LAN-mode status messages; made a small metadata tweak in `model_allowlist.json`. 

### Testing
- Performed an Android debug build via `./gradlew assembleDebug`, which completed successfully. 
- Ran unit tests via `./gradlew test`, which passed without failures. 
- Ran basic lint/build checks as part of the local verification and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc361684c48331825ec7a757440ede)